### PR TITLE
Add workstation as a valid environment

### DIFF
--- a/app/io/flow/play/util/ErrorHandler.scala
+++ b/app/io/flow/play/util/ErrorHandler.scala
@@ -36,7 +36,7 @@ class ErrorHandler extends HttpErrorHandler {
     Logger.error(s"Error[$errorId] ${request.method} ${request.path}", exception)
 
     val msg = FlowEnvironment.Current match {
-      case FlowEnvironment.Development => s"A server error has occurred (#$errorId). Additional info for development environment: $exception"
+      case FlowEnvironment.Development | FlowEnvironment.Workstation => s"A server error has occurred (#$errorId). Additional info for development environment: $exception"
       case FlowEnvironment.Production => s"A server error has occurred (#$errorId)"
     }
 

--- a/app/io/flow/play/util/FlowEnvironment.scala
+++ b/app/io/flow/play/util/FlowEnvironment.scala
@@ -6,9 +6,9 @@ sealed trait FlowEnvironment
   * We introduced our own environment primarily to support our
   * dockerized environments and to integrate nicely with the flow
   * registry. The environment is used by the registry to identify
-  * hostnames to use in either production or development, and within
-  * development, we needed a way to reliably identify our intended
-  * environment as opposed to the Play environment.
+  * hostnames to use in either production, development or workstation,
+  * and within workstation, we needed a way to reliably identify our
+  * intended environment as opposed to the Play environment.
   * 
   * Specifically, we use sbt stage to create the run scripts for
   * play. These scripts are the entrypoints in the docker containers
@@ -25,7 +25,8 @@ sealed trait FlowEnvironment
   *   2. a system property named 'FLOW_ENV'
   *   3. a default of 'development'
   * 
-  * Valid values for the environment are: 'development' or 'production'
+  * Valid values for the environment are: 'development',
+  * 'workstation', 'production'
   * 
   * To get the current environment:
   * 
@@ -33,16 +34,17 @@ sealed trait FlowEnvironment
   *
   *     FlowEnvironment.Current match {
   *       case FlowEnvironment.Development => ...
+  *       case FlowEnvironment.Workstation => ...
   *       case FlowEnvironment.Production => ...
   *     }
   */
 object FlowEnvironment {
 
   case object Development extends FlowEnvironment { override def toString() = "development" }
-
   case object Production extends FlowEnvironment { override def toString() = "production" }
+  case object Workstation extends FlowEnvironment { override def toString() = "workstation" }
 
-  val all = Seq(Development, Production)
+  val all = Seq(Development, Production, Workstation)
 
   private[this]
   val byName = all.map(x => x.toString.toLowerCase -> x).toMap

--- a/test/io/flow/play/util/FlowEnvironmentSpec.scala
+++ b/test/io/flow/play/util/FlowEnvironmentSpec.scala
@@ -19,7 +19,7 @@ class FlowEnvironmentSpec extends FunSpec with Matchers {
     FlowEnvironment.parse("test", "production") should be(FlowEnvironment.Production)
     intercept[Throwable] {
       FlowEnvironment.parse("test", "other")
-    }.getMessage should be("Value[other] from test[FLOW_ENV] is invalid. Valid values are: development, production")
+    }.getMessage should be("Value[other] from test[FLOW_ENV] is invalid. Valid values are: development, production, workstation")
   }
 
 }

--- a/test/io/flow/play/util/FlowEnvironmentSpec.scala
+++ b/test/io/flow/play/util/FlowEnvironmentSpec.scala
@@ -7,6 +7,7 @@ class FlowEnvironmentSpec extends FunSpec with Matchers {
   it("fromString") {
     FlowEnvironment.fromString("development") should be(Some(FlowEnvironment.Development))
     FlowEnvironment.fromString("production") should be(Some(FlowEnvironment.Production))
+    FlowEnvironment.fromString("workstation") should be(Some(FlowEnvironment.Workstation))
   }
 
   it("Current is defined") {


### PR DESCRIPTION
 - Remove DEV_HOST environment variable
 - Add optional WORKSTATION_HOST env variable, with a default value of 'ws'
 - Remove FLOW_API_TOKEN as well (registry is now public for readers)
 - Add "workstation" as a first class value for FlowEnvironment