### PR TITLE
Propagate request header through auth data

### DIFF
--- a/app/io/flow/play/controllers/AuthDataFromFlowAuthHeader.scala
+++ b/app/io/flow/play/controllers/AuthDataFromFlowAuthHeader.scala
@@ -41,7 +41,7 @@ trait AuthDataFromFlowAuthHeader  {
         claims.get("created_at").flatMap { ts =>
           val requestId = claims.get("request_id").getOrElse {
             Logger.warn("JWT Token did not have a request_id - generated a new request id")
-            UUID.randomUUID.toString
+            "lib-play-" + UUID.randomUUID.toString
           }
 
           val createdAt = ISODateTimeFormat.dateTimeParser.parseDateTime(ts)

--- a/app/io/flow/play/controllers/UserFromFlowAuth.scala
+++ b/app/io/flow/play/controllers/UserFromFlowAuth.scala
@@ -2,6 +2,7 @@ package io.flow.play.controllers
 
 import io.flow.common.v0.models.UserReference
 import io.flow.play.util.AuthData
+import java.util.UUID
 import org.joda.time.DateTime
 import play.api.mvc.{Headers, Session}
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -28,7 +29,9 @@ trait UserFromFlowAuth extends AuthDataFromFlowAuthHeader {
           legacyUser(headers),
           Duration(5, "seconds")
         ).map { u =>
+          val requestId: String = headers.get("X-Flow-Request-Id").getOrElse(UUID.randomUUID.toString)
           AuthData(
+            requestId = requestId,
             createdAt = new DateTime(),
             user = u,
             organization = None

--- a/app/io/flow/play/controllers/UserFromFlowAuth.scala
+++ b/app/io/flow/play/controllers/UserFromFlowAuth.scala
@@ -29,7 +29,7 @@ trait UserFromFlowAuth extends AuthDataFromFlowAuthHeader {
           legacyUser(headers),
           Duration(5, "seconds")
         ).map { u =>
-          val requestId: String = headers.get("X-Flow-Request-Id").getOrElse(UUID.randomUUID.toString)
+          val requestId: String = headers.get("X-Flow-Request-Id").getOrElse("lib-play-depr-" + UUID.randomUUID.toString)
           AuthData(
             requestId = requestId,
             createdAt = new DateTime(),

--- a/app/io/flow/play/util/LoggingFilter.scala
+++ b/app/io/flow/play/util/LoggingFilter.scala
@@ -31,6 +31,7 @@ class FlowLoggingFilter @javax.inject.Inject() (implicit ec: ExecutionContext) e
         s"${requestHeader.host}${requestHeader.uri}",
         result.header.status,
         s"${requestTime}ms",
+        headerMap.getOrElse("X-Flow-Request-Id", Nil).mkString(","),
         headerMap.getOrElse("User-Agent", Nil).mkString(","),
         headerMap.getOrElse("X-Forwarded-For", Nil).mkString(","),
         headerMap.getOrElse("CF-Connecting-IP", Nil).mkString(",")

--- a/test/io/flow/play/controllers/AuthDataFromFlowAuthHeaderSpec.scala
+++ b/test/io/flow/play/controllers/AuthDataFromFlowAuthHeaderSpec.scala
@@ -33,6 +33,7 @@ class AuthDataFromFlowAuthHeaderSpec extends PlaySpec with OneAppPerSuite {
     val ts = new DateTime()
     val user = UserReference("usr-20151006-1")
     val data = AuthData(
+      requestId = "test",
       createdAt = ts,
       user = user,
       organization = None
@@ -41,6 +42,7 @@ class AuthDataFromFlowAuthHeaderSpec extends PlaySpec with OneAppPerSuite {
     val result = testTrait.parse(data.jwt(salt)).getOrElse {
       sys.error("Failed to parse")
     }
+    result.requestId must be("test")
     result.createdAt must be(ts)
     result.user must be(user)
     result.organization must be(None)
@@ -55,6 +57,7 @@ class AuthDataFromFlowAuthHeaderSpec extends PlaySpec with OneAppPerSuite {
       environment = Environment.Sandbox
     )
     val data = AuthData(
+      requestId = "test2",
       createdAt = ts,
       user = user,
       organization = Some(org)
@@ -63,6 +66,7 @@ class AuthDataFromFlowAuthHeaderSpec extends PlaySpec with OneAppPerSuite {
     val result = testTrait.parse(data.jwt(salt)).getOrElse {
       sys.error("Failed to parse")
     }
+    result.requestId must be("test2")
     result.createdAt must be(ts)
     result.user must be(user)
     result.organization must be(Some(org))
@@ -72,6 +76,7 @@ class AuthDataFromFlowAuthHeaderSpec extends PlaySpec with OneAppPerSuite {
     val ts = (new DateTime()).plusMinutes(5)
     val user = UserReference("usr-20151006-1")
     val data = AuthData(
+      requestId = "test2",
       createdAt = ts,
       user = user,
       organization = None

--- a/test/io/flow/play/util/AuthDataSpec.scala
+++ b/test/io/flow/play/util/AuthDataSpec.scala
@@ -7,13 +7,14 @@ class AuthDataSpec extends FunSpec with Matchers {
 
   it("AuthData.user") {
     val id = "user-1"
-    val auth = AuthData.user(UserReference(id))
+    val auth = AuthData.user("test1", UserReference(id))
+    auth.requestId should be("test1")
     auth.user.id should be(id)
     auth.organization should be(None)
   }
 
   it("AuthData.organization defaults") {
-    val auth = AuthData.organization(UserReference("user-1"), "demo")
+    val auth = AuthData.organization("test2", UserReference("user-1"), "demo")
     auth.user.id should be("user-1")
     auth.organization should be(
       Some(
@@ -23,7 +24,7 @@ class AuthDataSpec extends FunSpec with Matchers {
   }
 
   it("AuthData.organization") {
-    val auth = AuthData.organization(UserReference("user-1"), "demo", Role.Admin, Environment.Production)
+    val auth = AuthData.organization("test2", UserReference("user-1"), "demo", Role.Admin, Environment.Production)
     auth.user.id should be("user-1")
     auth.organization should be(
       Some(


### PR DESCRIPTION
 - Also add a helper class - AuthHeaders - that we can inject to
   generate fresh auth headers when one service calls another on
   behalf of a request
 - Log request Id as part of logging filter