### PR TITLE
Add IdentifiedOrg to make it simple to assert that org auth is present

### DIFF
--- a/app/io/flow/play/controllers/AuthDataFromFlowAuthHeader.scala
+++ b/app/io/flow/play/controllers/AuthDataFromFlowAuthHeader.scala
@@ -103,7 +103,7 @@ trait AuthDataFromFlowAuthHeader  {
     implicit ec: ExecutionContext
   ): Future[Option[UserReference]] = {
     basicAuthorizationToken(headers) match {
-      case None => Future { None }
+      case None => Future(None)
       case Some(token) => {
         token match {
           case token: Authorization.Token => {
@@ -117,9 +117,9 @@ trait AuthDataFromFlowAuthHeader  {
 
           }
           case token: Authorization.JwtToken => {
-            Future {
+            Future(
               Some(UserReference(token.userId))
-            }
+            )
           }
         }
       }

--- a/app/io/flow/play/controllers/FlowControllerHelpers.scala
+++ b/app/io/flow/play/controllers/FlowControllerHelpers.scala
@@ -64,7 +64,7 @@ trait FlowControllerHelpers {
         contentType,
         body,
         function,
-        { errorResult => Future { errorResult } }
+        { errorResult => Future(errorResult) }
       )
     }
 
@@ -136,7 +136,7 @@ trait FlowControllerHelpers {
         expand,
         records,
         function,
-        { errorResult => Future { errorResult } },
+        { errorResult => Future(errorResult) },
         requestHeaders = requestHeaders
 
       )

--- a/app/io/flow/play/controllers/IdentifiedController.scala
+++ b/app/io/flow/play/controllers/IdentifiedController.scala
@@ -26,9 +26,9 @@ trait IdentifiedController extends AnonymousController {
 
     def invokeBlock[A](request: Request[A], block: (IdentifiedRequest[A]) => Future[Result]) = {
       auth(request.headers) match {
-        case None => {
-          Future { unauthorized(request) }
-        }
+        case None => Future(
+          unauthorized(request)
+        )
         case Some(auth) => {
           block(
             new IdentifiedRequest(auth, request)

--- a/app/io/flow/play/controllers/IdentifiedOrgController.scala
+++ b/app/io/flow/play/controllers/IdentifiedOrgController.scala
@@ -1,0 +1,51 @@
+package io.flow.play.controllers
+
+import io.flow.common.v0.models.{UserReference, User}
+import io.flow.play.util.{AuthData, OrganizationAuthData}
+import play.api.mvc.Results.Unauthorized
+import scala.concurrent.Future
+import play.api.mvc._
+
+/**
+  * Provides helpers for actions that require a user and an
+  * organization to be identified.
+  */
+trait IdentifiedOrgController extends AnonymousController {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  def unauthorized[A](request: Request[A]): Result = Unauthorized
+
+  class IdentifiedOrgRequest[A](
+    val auth: AuthData,
+    val orgAuth: OrganizationAuthData,
+    request: Request[A]
+  ) extends WrappedRequest[A](request) {
+    val user = auth.user
+    val organization = orgAuth.organization
+    val environment = orgAuth.environment
+  }
+
+  object IdentifiedOrg extends ActionBuilder[IdentifiedOrgRequest] {
+
+    def invokeBlock[A](request: Request[A], block: (IdentifiedOrgRequest[A]) => Future[Result]) = {
+      auth(request.headers) match {
+        case None => Future(
+          unauthorized(request)
+        )
+        case Some(auth) => {
+          auth.organization match {
+            case None => Future (
+              unauthorized(request)
+            )
+            case Some(org) => {
+              block(
+                new IdentifiedOrgRequest(auth, org, request)
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/io/flow/play/controllers/UserFromFlowAuth.scala
+++ b/app/io/flow/play/controllers/UserFromFlowAuth.scala
@@ -53,7 +53,7 @@ trait UserFromFlowAuth extends AuthDataFromFlowAuthHeader {
     implicit ec: ExecutionContext
   ): Future[Option[UserReference]] = {
     basicAuthorizationToken(headers) match {
-      case None => Future { None }
+      case None => Future(None)
       case Some(token) => {
         token match {
           case token: Authorization.Token => {
@@ -67,9 +67,9 @@ trait UserFromFlowAuth extends AuthDataFromFlowAuthHeader {
 
           }
           case token: Authorization.JwtToken => {
-            Future {
+            Future(
               Some(UserReference(token.userId))
-            }
+            )
           }
         }
       }

--- a/app/io/flow/play/expanders/User.scala
+++ b/app/io/flow/play/expanders/User.scala
@@ -24,9 +24,9 @@ case class User (
     }
 
     userIds match {
-      case Nil => Future {
+      case Nil => Future(
         records
-      }
+      )
       case ids => {
         userClient.users.get(id = Some(ids), limit = userIds.size, requestHeaders = requestHeaders).map(users =>
           Map(users.map(user => user.id -> user): _*)


### PR DESCRIPTION
- enables us to call request.organization and request.environment
    directly
  - also minor tweak to use Future() instead of Future {} when
    there is no need for another thread