### PR TITLE
Way to specify methods to log http requests for

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ Library supporting building REST APIs on play framework.
     play.modules.enabled += "io.flow.play.clients.TokenModule"
     play.modules.enabled += "io.flow.play.clients.UserModule"
 
+## Request Logging
+
+To enable request logging, add the following to your
+play application config:
+
+    play.http.filters=io.flow.play.util.LoggingFilter
+
+By default, all HTTP methods will be logged. To only
+log a specific subset of methods, add the following:
+
+    play.http.filters.logging.methods=["GET", "PUT"]
+
+## CORS
+
+A CORS request handler is provided. To enable, add the following
+to your play application config (instead of `LoggingFilter` above):
+
+    play.http.filters=io.flow.play.util.CorsWithLoggingFilter
+    play.filters.cors.allowedHttpMethods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+
 ## Global error handler for JSON APIs
 
 This error handler capture client and server errors, always
@@ -31,7 +51,7 @@ leaking information).
    -- Provides user(...) method to get an instance of the current
       user.
     -- (type: Option[User])
-    
+
   Identified Controller
     -- extends Anonymous
     -- requires a user to be present

--- a/app/io/flow/play/clients/MockConfig.scala
+++ b/app/io/flow/play/clients/MockConfig.scala
@@ -7,8 +7,19 @@ case class MockConfig @javax.inject.Inject() (
   defaultConfig: DefaultConfig
 ) extends Config {
 
+  override def optionalList(name: String): Option[Seq[String]] = {
+    values.get(name) match {
+      case Some(v) => Some(v.asInstanceOf[Seq[String]])
+      case None => defaultConfig.optionalList(name)
+    }
+  }
+
+  def set(name: String, value: Seq[String]) {
+    values += (name -> value)
+  }
+
   val values = {
-    val d = scala.collection.mutable.Map[String, String]()
+    val d = scala.collection.mutable.Map[String, Any]()
     d += ("JWT_SALT" -> "test")
     d
   }
@@ -19,7 +30,7 @@ case class MockConfig @javax.inject.Inject() (
 
   override def get(name: String): Option[String] = {
     values.get(name) match {
-      case Some(v) => Some(v)
+      case Some(v) => Some(v.toString)
       case None => defaultConfig.get(name)
     }
   }

--- a/app/io/flow/play/util/LoggingFilter.scala
+++ b/app/io/flow/play/util/LoggingFilter.scala
@@ -21,7 +21,7 @@ class FlowLoggingFilter @javax.inject.Inject() (
   implicit ec: ExecutionContext,
   config: Config
 ) extends Filter {
-  val LoggedRequestMethodConfig = ""
+  val LoggedRequestMethodConfig = "play.http.filters.logging.methods"
   val DefaultLoggedRequestMethods = Seq("GET", "PATCH", "POST", "PUT", "DELETE", "OPTIONS")
 
   def apply(f: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {

--- a/app/io/flow/play/util/LoggingFilter.scala
+++ b/app/io/flow/play/util/LoggingFilter.scala
@@ -17,26 +17,37 @@ class LoggingFilter @javax.inject.Inject() (loggingFilter: FlowLoggingFilter) ex
   def filters = Seq(loggingFilter)
 }
 
-class FlowLoggingFilter @javax.inject.Inject() (implicit ec: ExecutionContext) extends Filter {
+class FlowLoggingFilter @javax.inject.Inject() (
+  implicit ec: ExecutionContext,
+  config: Config
+) extends Filter {
+  val LoggedRequestMethodConfig = ""
+  val DefaultLoggedRequestMethods = Seq("GET", "PATCH", "POST", "PUT", "DELETE", "OPTIONS")
+
   def apply(f: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     val startTime = System.currentTimeMillis
     f(requestHeader).map { result =>
-      val endTime = System.currentTimeMillis
-      val requestTime = endTime - startTime
+      /**
+        * If user defined a list of methods that produce logs, then use that
+        * Otherwise default to list defined here, which is everything
+        */
+      if (config.optionalList(LoggedRequestMethodConfig).getOrElse(DefaultLoggedRequestMethods).contains(requestHeader.method)) {
+        val endTime = System.currentTimeMillis
+        val requestTime = endTime - startTime
+        val headerMap = requestHeader.headers.toMap
+        val line = Seq(
+          requestHeader.method,
+          s"${requestHeader.host}${requestHeader.uri}",
+          result.header.status,
+          s"${requestTime}ms",
+          headerMap.getOrElse("X-Flow-Request-Id", Nil).mkString(","),
+          headerMap.getOrElse("User-Agent", Nil).mkString(","),
+          headerMap.getOrElse("X-Forwarded-For", Nil).mkString(","),
+          headerMap.getOrElse("CF-Connecting-IP", Nil).mkString(",")
+        ).mkString(" ")
 
-      val headerMap = requestHeader.headers.toMap
-
-      val line = Seq(
-        requestHeader.method,
-        s"${requestHeader.host}${requestHeader.uri}",
-        result.header.status,
-        s"${requestTime}ms",
-        headerMap.getOrElse("X-Flow-Request-Id", Nil).mkString(","),
-        headerMap.getOrElse("User-Agent", Nil).mkString(","),
-        headerMap.getOrElse("X-Forwarded-For", Nil).mkString(","),
-        headerMap.getOrElse("CF-Connecting-IP", Nil).mkString(",")
-      ).mkString(" ")
-      Logger.info(line)
+        Logger.info(line)
+      }
 
       result
     }

--- a/test/io/flow/play/util/ConfigSpec.scala
+++ b/test/io/flow/play/util/ConfigSpec.scala
@@ -11,6 +11,13 @@ class ConfigSpec extends PlaySpec with OneAppPerSuite {
 
   def createTestId(): String = UUID.randomUUID.toString
 
+  "optionalList" in {
+    config.optionalList(createTestId())must be(None)
+
+    config.set("foo", Seq("a", "b", "c"))
+    config.optionalList("foo") must be(Some(Seq("a", "b", "c")))
+  }
+
   "optionalString" in {
     config.optionalString(createTestId())must be(None)
 


### PR DESCRIPTION
A large amount of GET requests are being logged and sent to Sumo for various services and this takes up our ingest limit. Most of these are not used and take up unnecessary bandwidth towards our limit, and we may not really find these useful when searching Sumo anyway.

This is a change to allow a developer to specify a list of HTTP methods which to log via the config. If a list in not provided in the play config, then default to all methods. This will allow most apps to function without any changes.