### PR TITLE
Add implicit ordering for `DateTime` in `DateHelper`

### DIFF
--- a/app/io/flow/play/util/DateHelper.scala
+++ b/app/io/flow/play/util/DateHelper.scala
@@ -45,6 +45,9 @@ trait DateFormats {
   */
 object DateHelper extends DateFormats {
 
+  /** This implicit ordering allows us to called `.sorted` on a Seq[DateTime]. */
+  implicit def dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
+
   val CopyrightStartYear = 2016
 
   val EasternTimezone = DateTimeZone.forID("America/New_York")

--- a/test/io/flow/play/util/DateHelperSpec.scala
+++ b/test/io/flow/play/util/DateHelperSpec.scala
@@ -68,4 +68,16 @@ class DateHelperSpec extends PlaySpec with OneAppPerSuite {
     Seq("2016", s"2016 - ${DateHelper.currentYear}").contains(value) mustBe(true)
   }
 
+  "implicit ordering" in {
+    import DateHelper._
+    val now = DateTime.now
+    val nowPlus1 = now.plusMinutes(1)
+    val nowPlus5 = now.plusMinutes(5)
+    val nowPlus10 = now.plusMinutes(10)
+
+    val datetimes = Seq(nowPlus10, nowPlus5, nowPlus1, now)
+
+    datetimes.sorted must equal(datetimes.reverse)
+  }
+
 }


### PR DESCRIPTION
Introducing this implicit ordering into `lib-play` allows us to remove it from the following places:

-  https://github.com/flowcommerce/fulfillment/blob/0674c3cd2cfc1b9dae21814578b63f42f9c65ad8/api/app/utils/DeliveryWindowUtil.scala#L80
- https://github.com/flowcommerce/currency/blob/66c8e40d52e1b1e787a49503d2e3659b9bccb3f3/api/test/db/Helpers.scala#L19
- https://github.com/flowcommerce/billing/blob/e4a4503507e888de7f1aa02855bf157ecc59f9c7/api/app/util/BillingStatementEmail.scala#L71-
- https://github.com/flowcommerce/billing/blob/3bd4c136d76ef4cc8fc527216f436426f57c4d92/api/app/actors/kinesis/ExperienceEvent.scala#L46

I'll also end up using it in `search`.