### PR TITLE
Revert "Update travis config to build pushes on master only"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,3 @@ script:
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
-branches:
-  only:
-    - master


### PR DESCRIPTION
This reverts commit 001f7f6f258111091dded775487d5933148b7955.

Since builds were disabled for PRs, I merged an upgrade to `authentikat` that caused the build on `master` to fail. Without realizing the build was broken, I released the lib and upgraded its dependents. Ideally, we should know before merging to `master` whether a change breaks the build.