### PR TITLE
Change default expiration to 3 minutes

### DIFF
--- a/app/io/flow/play/controllers/AuthDataFromFlowAuthHeader.scala
+++ b/app/io/flow/play/controllers/AuthDataFromFlowAuthHeader.scala
@@ -18,7 +18,7 @@ trait AuthDataFromFlowAuthHeader  {
 
   def jwtSalt: String = config.requiredString("JWT_SALT")
 
-  private[this] val DefaultAuthExpirationTimeSeconds = 120
+  private[this] val DefaultAuthExpirationTimeSeconds = 180
 
   private[this] lazy val authExpirationTimeSeconds = config.optionalInt("FLOW_AUTH_EXPIRATION_SECONDS").getOrElse(DefaultAuthExpirationTimeSeconds)
   


### PR DESCRIPTION
  - Proxy servers ended up 1 minute out of sync
  - Payment auth took 1 minute
  - Request incorrectly timed out
  - Changing to 3 minutes to give a bit more buffer