### PR TITLE
Move Urls downloader util from harmonization to lib-play

### DIFF
--- a/app/io/flow/play/util/Urls.scala
+++ b/app/io/flow/play/util/Urls.scala
@@ -1,15 +1,19 @@
 package io.flow.play.util
 
+import sys.process._
 import java.net.URL
 import java.io.File
-import org.apache.commons.io.FileUtils
 
 object Urls {
 
-  def downloadToFile(url: String, prefix: String, suffix: String): File = {
-    val tmp = File.createTempFile(prefix, suffix)
-    FileUtils.copyURLToFile(new URL(url), tmp)
-    tmp
+  def downloadToFile(url: String, file: File): File = {
+    new URL(url) #> file !!
+
+    file
+  }
+
+  def downloadToTmpFile(url: String, prefix: String, suffix: String): File = {
+    downloadToFile(url, File.createTempFile(prefix, suffix))
   }
 
 }

--- a/app/io/flow/play/util/Urls.scala
+++ b/app/io/flow/play/util/Urls.scala
@@ -1,0 +1,15 @@
+package io.flow.play.util
+
+import java.net.URL
+import java.io.File
+import org.apache.commons.io.FileUtils
+
+object Urls {
+
+  def downloadToFile(url: String, prefix: String, suffix: String): File = {
+    val tmp = File.createTempFile(prefix, suffix)
+    FileUtils.copyURLToFile(new URL(url), tmp)
+    tmp
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,7 @@ lazy val root = project
       ws,
       filters,
       "com.jason-goodwin" %% "authentikat-jwt" % "0.4.3",
-      "org.scalatestplus" %% "play" % "1.4.0" % "test",
-      "org.apache.commons" % "commons-io" % "1.3.2"
+      "org.scalatestplus" %% "play" % "1.4.0" % "test"
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
     resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ lazy val root = project
       ws,
       filters,
       "com.jason-goodwin" %% "authentikat-jwt" % "0.4.3",
-      "org.scalatestplus" %% "play" % "1.4.0" % "test"
+      "org.scalatestplus" %% "play" % "1.4.0" % "test",
+      "org.apache.commons" % "commons-io" % "1.3.2"
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
     resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",


### PR DESCRIPTION
I plan to use this also in catalog api when doing the catalog item upsert event importer