### PR TITLE
Optimize Random performance

### DIFF
--- a/app/io/flow/play/util/Random.scala
+++ b/app/io/flow/play/util/Random.scala
@@ -1,36 +1,37 @@
 package io.flow.play.util
 
+
 /**
   * Wrapper on the scala random libraries providing higher level
   * common functions.
   */
 case class Random() {
 
-  private[this] val random = new java.security.SecureRandom
+  import Random._
 
-  private[this] val Ambiguous = "B8G6I1l0OoQDS5Z2".split("")
-  private[this] val Numbers = "0123456789"
-  private[this] val Lower = "abcdefghijklmnopqrstuvwxyz"
-  private[this] val LowerAndUpper = Lower + Lower.toUpperCase
-  private[this] val LowerAndUpperAndNumbers = LowerAndUpper + Numbers
-  private[this] val NonAmbiguousLowerAndUpper = LowerAndUpper.split("").filter(!Ambiguous.contains(_)).mkString("")
-  private[this] val NonAmbiguousLowerAndUpperAndNumbers = NonAmbiguousLowerAndUpper + "3479"
+  private[this] val random = new java.security.SecureRandom
 
   /**
     * Generate a random string of length n from the given alphabet
-    * 
-    * @param alphabet The complete set of 
+    *
+    * @param alphabet The complete set of
     * @param n Length of random string to generate
     */
   def string(alphabet: String)(n: Int): String = {
     assert(n > 0, "n must be > 0")
-    Stream.continually(random.nextInt(alphabet.length)).map(alphabet).take(n).mkString
+    val s = new StringBuilder(n)
+    var i = n
+    while (i > 0) {
+      s.append(alphabet(random.nextInt(alphabet.length)))
+      i -= 1
+    }
+    s.toString()
   }
 
   /**
     * Generate a random string of length n using only a-z (lower case
     * alphabet letters)
-    * 
+    *
     * @param n Length of random string to generate
     */
   def lowercaseAlpha(n: Int): String = {
@@ -40,7 +41,7 @@ case class Random() {
   /**
     * Generate a random string of length n using only a-z and A-Z
     * (alphabet letters only)
-    * 
+    *
     * @param n Length of random string to generate
     */
   def alpha(n: Int): String = {
@@ -53,38 +54,44 @@ case class Random() {
     * will start with a letter, not a number - this is mostly to
     * prevent problems with any applications that infer numeric based
     * on first digit (or strip zeroes).
-    * 
+    *
     * The random string is guaranteed to start with a letter (we do
     * this to avoid confusion in some programs like excel which can
     * infer a numeric type based on the first character)
-    * 
+    *
     * @param n Length of random string to generate
     */
   def alphaNumeric(n: Int): String = {
     if (n == 1) {
       alpha(1)
     } else {
-      alpha(1) + string(LowerAndUpperAndNumbers)(n - 1)
+      val s = new StringBuilder(n)
+      s.append( alpha(1))
+      s.append(string(LowerAndUpperAndNumbers)(n - 1))
+      s.toString()
     }
   }
 
-    /**
+  /**
     * Generate a random string of length n using only letters and
     * numbers that are non ambiguous (e.g. B can look like an 8 so
     * neither B nor 8 is used in the random string). This is a good
     * option for random strings that will be read by humans.
-    * 
+    *
     * The random string is guaranteed to start with a letter (we do
     * this to avoid confusion in some programs like excel which can
     * infer a numeric type based on the first character)
-    * 
+    *
     * @param n Length of random string to generate
     */
   def alphaNumericNonAmbiguous(n: Int): String = {
     if (n == 1) {
       string(NonAmbiguousLowerAndUpper)(1)
     } else {
-      string(NonAmbiguousLowerAndUpper)(1) + string(NonAmbiguousLowerAndUpperAndNumbers)(n - 1)
+      val s = new StringBuilder(n)
+      s.append(string(NonAmbiguousLowerAndUpper)(1))
+      s.append(string(NonAmbiguousLowerAndUpperAndNumbers)(n - 1))
+      s.toString()
     }
   }
 
@@ -93,7 +100,7 @@ case class Random() {
     */
   @scala.annotation.tailrec
   final def positiveInt(): Int = {
-    val value = random.nextInt
+    val value = random.nextInt()
     if (value > 0) {
       value
     } else {
@@ -113,5 +120,17 @@ case class Random() {
       positiveLong()
     }
   }
+
+}
+
+object Random {
+
+  private val Ambiguous = "B8G6I1l0OoQDS5Z2".split("")
+  private val Numbers = "0123456789"
+  private val Lower = "abcdefghijklmnopqrstuvwxyz"
+  private val LowerAndUpper = Lower + Lower.toUpperCase
+  private val LowerAndUpperAndNumbers = LowerAndUpper + Numbers
+  private val NonAmbiguousLowerAndUpper = LowerAndUpper.split("").filter(!Ambiguous.contains(_)).mkString("")
+  private val NonAmbiguousLowerAndUpperAndNumbers = NonAmbiguousLowerAndUpper + "3479"
 
 }

--- a/app/io/flow/play/util/Random.scala
+++ b/app/io/flow/play/util/Random.scala
@@ -66,7 +66,7 @@ case class Random() {
       alpha(1)
     } else {
       val s = new StringBuilder(n)
-      s.append( alpha(1))
+      s.append(alpha(1))
       s.append(string(LowerAndUpperAndNumbers)(n - 1))
       s.toString()
     }


### PR DESCRIPTION
This follows the load test on `session` where it appeared that ~80% of the cpu time was spent in `Random.string()`. I am not necessarily convinced that this is case but I just wanted to take a look at it.

I benchmarked the changes using [scalameter](https://scalameter.github.io/):

```scala
package io.flow.play.util

import org.scalameter.api._
import org.scalameter.picklers.Implicits._

object RandomBenchmark extends Bench[Double] {

  /* configuration */
  lazy val executor = LocalExecutor(
    new Executor.Warmer.Default,
    Aggregator.min[Double],
    measurer)
  lazy val measurer = new Measurer.Default
  lazy val reporter = new LoggingReporter[Double]
  lazy val persistor = Persistor.None

  /* inputs */
  val sizes = Gen.range("size")(10, 100, 10)

  /* tests */

  performance of "OldRandom" in {
    measure method "alphaNumeric" in {
      using(sizes) in { size =>
        (1 to 1000).foreach { _ =>
          new OldRandom().alphaNumeric(size)
        }
      }
    }
  }

  performance of "NewRandom" in {
    measure method "alphaNumeric" in {
      using(sizes) in { size =>
        (1 to 1000).foreach { _ =>
          new NewRandom().alphaNumeric(size)
        }
      }
    }
  }

  performance of "HalfNewRandom" in {
    measure method "alphaNumeric" in {
      using(sizes) in { size =>
        (1 to 1000).foreach { _ =>
          new HalfNewRandom().alphaNumeric(size)
        }
      }
    }
  }
}
```

Where `NewRandom` is the new implementation, `OldRandom` the current implementation before this PR, and `HalfNewRandom` has the same implementations as `OldRandom` but with the initial alphabet objects extracted to a static `object` like in the `NewRandom` implementation. The goal of `HalfNewRandom` being to compare purely the implementations.


Results:

```
[info] ::Benchmark OldRandom.alphaNumeric::
[info] cores: 8
[info] hostname: Jeans-MacBook-Pro.local
[info] name: Java HotSpot(TM) 64-Bit Server VM
[info] osArch: x86_64
[info] osName: Mac OS X
[info] vendor: Oracle Corporation
[info] version: 25.131-b11
[info] Parameters(size -> 10): 11.120037
[info] Parameters(size -> 20): 16.102848
[info] Parameters(size -> 30): 21.411941
[info] Parameters(size -> 40): 27.860157
[info] Parameters(size -> 50): 33.271442
[info] Parameters(size -> 60): 35.709906
[info] Parameters(size -> 70): 43.169281
[info] Parameters(size -> 80): 49.771466
[info] Parameters(size -> 90): 53.659094
[info] Parameters(size -> 100): 60.048766
[info]
[info] ::Benchmark NewRandom.alphaNumeric::
[info] cores: 8
[info] hostname: Jeans-MacBook-Pro.local
[info] name: Java HotSpot(TM) 64-Bit Server VM
[info] osArch: x86_64
[info] osName: Mac OS X
[info] vendor: Oracle Corporation
[info] version: 25.131-b11
[info] Parameters(size -> 10): 1.650546
[info] Parameters(size -> 20): 7.382376
[info] Parameters(size -> 30): 9.024199
[info] Parameters(size -> 40): 14.826936
[info] Parameters(size -> 50): 20.520811
[info] Parameters(size -> 60): 21.933397
[info] Parameters(size -> 70): 27.67655
[info] Parameters(size -> 80): 31.751167
[info] Parameters(size -> 90): 35.114744
[info] Parameters(size -> 100): 40.919177
[info]
[info] ::Benchmark HalfNewRandom.alphaNumeric::
[info] cores: 8
[info] hostname: Jeans-MacBook-Pro.local
[info] name: Java HotSpot(TM) 64-Bit Server VM
[info] osArch: x86_64
[info] osName: Mac OS X
[info] vendor: Oracle Corporation
[info] version: 25.131-b11
[info] Parameters(size -> 10): 3.010721
[info] Parameters(size -> 20): 10.190576
[info] Parameters(size -> 30): 13.063878
[info] Parameters(size -> 40): 20.324962
[info] Parameters(size -> 50): 27.975726
[info] Parameters(size -> 60): 30.90019
[info] Parameters(size -> 70): 38.447444
[info] Parameters(size -> 80): 41.851183
[info] Parameters(size -> 90): 48.43049
[info] Parameters(size -> 100): 54.953985
[info]
```

The proposed implementation is indeed faster that the two other implementations.

Should we expect any noticeable gain? At ~13ms  for 1000 strings of length 50 (~40% gain), most likely not.
