### PR TITLE
Optimize random positive

### DIFF
--- a/app/io/flow/play/util/Random.scala
+++ b/app/io/flow/play/util/Random.scala
@@ -98,12 +98,28 @@ case class Random() {
   /**
     * Generate a random positive int
     */
-  final def positiveInt(): Int = random.nextInt() & Int.MaxValue
+  @scala.annotation.tailrec
+  final def positiveInt(): Int = {
+    val value = random.nextInt()
+    if (value > 0) {
+      value
+    } else {
+      positiveInt()
+    }
+  }
 
   /**
     * Generate a random positive long
     */
-  final def positiveLong(): Long = random.nextLong() & Long.MaxValue
+  @scala.annotation.tailrec
+  final def positiveLong(): Long = {
+    val value = random.nextLong
+    if (value > 0) {
+      value
+    } else {
+      positiveLong()
+    }
+  }
 
 }
 

--- a/app/io/flow/play/util/Random.scala
+++ b/app/io/flow/play/util/Random.scala
@@ -98,28 +98,12 @@ case class Random() {
   /**
     * Generate a random positive int
     */
-  @scala.annotation.tailrec
-  final def positiveInt(): Int = {
-    val value = random.nextInt()
-    if (value > 0) {
-      value
-    } else {
-      positiveInt()
-    }
-  }
+  final def positiveInt(): Int = random.nextInt() & Int.MaxValue
 
   /**
     * Generate a random positive long
     */
-  @scala.annotation.tailrec
-  final def positiveLong(): Long = {
-    val value = random.nextLong
-    if (value > 0) {
-      value
-    } else {
-      positiveLong()
-    }
-  }
+  final def positiveLong(): Long = random.nextLong() & Long.MaxValue
 
 }
 


### PR DESCRIPTION
Optimize generation of positive numbers.

Similar tests as https://github.com/flowcommerce/lib-play/pull/178:

```scala
package io.flow.play.util

import org.scalameter.api._
import org.scalameter.picklers.Implicits._

object RandomBenchmark extends Bench[Double] {

  /* configuration */
  lazy val executor = LocalExecutor(
    new Executor.Warmer.Default,
    Aggregator.min[Double],
    measurer)
  lazy val measurer = new Measurer.Default
  lazy val reporter = new LoggingReporter[Double]
  lazy val persistor = Persistor.None

  /* inputs */
  val iterations = Gen.range("iteration")(1, 10, 1)

  /* tests */
  performance of "NewRandom" in {
    measure method "positiveLong" in {
      using(iterations) in { size =>
        (1 to 100000).foreach { _ =>
          new NewRandom().positiveLong()
        }
      }
    }
  }

  performance of "HalfNewRandom" in {
    measure method "positiveLong" in {
      using(iterations) in { size =>
        (1 to 100000).foreach { _ =>
          new HalfNewRandom().positiveLong()
        }
      }
    }
  }

}

```

Results:

```
[info] ::Benchmark NewRandom.positiveLong::
[info] cores: 8
[info] hostname: Jeans-MBP.home
[info] name: Java HotSpot(TM) 64-Bit Server VM
[info] osArch: x86_64
[info] osName: Mac OS X
[info] vendor: Oracle Corporation
[info] version: 25.131-b11
[info] Parameters(iteration -> 1): 96.380057
[info] Parameters(iteration -> 2): 97.778465
[info] Parameters(iteration -> 3): 96.402708
[info] Parameters(iteration -> 4): 97.296711
[info] Parameters(iteration -> 5): 97.445015
[info] Parameters(iteration -> 6): 96.406814
[info] Parameters(iteration -> 7): 96.022559
[info] Parameters(iteration -> 8): 97.184127
[info] Parameters(iteration -> 9): 99.14469
[info] Parameters(iteration -> 10): 100.416576
[info]
[info] ::Benchmark HalfNewRandom.positiveLong::
[info] cores: 8
[info] hostname: Jeans-MBP.home
[info] name: Java HotSpot(TM) 64-Bit Server VM
[info] osArch: x86_64
[info] osName: Mac OS X
[info] vendor: Oracle Corporation
[info] version: 25.131-b11
[info] Parameters(iteration -> 1): 177.566755
[info] Parameters(iteration -> 2): 183.11605
[info] Parameters(iteration -> 3): 184.382075
[info] Parameters(iteration -> 4): 180.298506
[info] Parameters(iteration -> 5): 181.211567
[info] Parameters(iteration -> 6): 174.105461
[info] Parameters(iteration -> 7): 179.487347
[info] Parameters(iteration -> 8): 188.085914
[info] Parameters(iteration -> 9): 177.463936
[info] Parameters(iteration -> 10): 185.297398
```

The proposed version using bit masks is ~55% faster.