### PR TITLE
Simplify FlowController and remove module

### DIFF
--- a/app/io/flow/play/controllers/FlowController.scala
+++ b/app/io/flow/play/controllers/FlowController.scala
@@ -2,6 +2,7 @@ package io.flow.play.controllers
 
 import javax.inject.Inject
 
+import com.google.inject.ImplementedBy
 import io.flow.common.v0.models.UserReference
 import io.flow.play.util.{AuthData, AuthHeaders, Config, OrgAuthData}
 import play.api.inject.Module
@@ -11,7 +12,6 @@ import play.api.{Configuration, Environment}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 
-
 /*
   USAGE:
   --------------------------------------------------------------
@@ -20,75 +20,51 @@ import scala.language.higherKinds
       val config: Config,
       val controllerComponents: ControllerComponents,
       val flowControllerComponents: FlowControllerComponents
-  3) Enable FlowControllerComponentsModule
-    in base.conf
-      play.modules.enabled += "io.flow.play.controllers.FlowControllerComponentsModule"
 */
 trait FlowController extends BaseController with BaseControllerHelpers with FlowControllerHelpers {
   protected def flowControllerComponents: FlowControllerComponents
 
-  def Anonymous: AnonymousActionBuilder[AnonymousRequest, AnyContent] = flowControllerComponents.anonymousActionBuilder
-  def Identified: IdentifiedActionBuilder[IdentifiedRequest, AnyContent] = flowControllerComponents.identifiedActionBuilder
-  def Session: SessionActionBuilder[SessionRequest, AnyContent] = flowControllerComponents.sessionActionBuilder
-  def Org: OrgActionBuilder[OrgRequest, AnyContent] = flowControllerComponents.orgActionBuilder
-  def IdentifiedOrg: IdentifiedOrgActionBuilder[IdentifiedOrgRequest, AnyContent] = flowControllerComponents.identifiedOrgActionBuilder
-  def SessionOrg: SessionOrgActionBuilder[SessionOrgRequest, AnyContent] = flowControllerComponents.sessionOrgActionBuilder
-  def IdentifiedCookie: IdentifiedCookieActionBuilder[IdentifiedRequest, AnyContent] = flowControllerComponents.identifiedCookieActionBuilder
+  def Anonymous: AnonymousActionBuilder = flowControllerComponents.anonymousActionBuilder
+  def Identified: IdentifiedActionBuilder = flowControllerComponents.identifiedActionBuilder
+  def Session: SessionActionBuilder = flowControllerComponents.sessionActionBuilder
+  def Org: OrgActionBuilder = flowControllerComponents.orgActionBuilder
+  def IdentifiedOrg: IdentifiedOrgActionBuilder = flowControllerComponents.identifiedOrgActionBuilder
+  def SessionOrg: SessionOrgActionBuilder = flowControllerComponents.sessionOrgActionBuilder
+  def IdentifiedCookie: IdentifiedCookieActionBuilder = flowControllerComponents.identifiedCookieActionBuilder
 
 }
 
+@ImplementedBy(classOf[FlowDefaultControllerComponents])
 trait FlowControllerComponents {
-  def anonymousActionBuilder: AnonymousActionBuilder[AnonymousRequest, AnyContent]
-  def identifiedActionBuilder: IdentifiedActionBuilder[IdentifiedRequest, AnyContent]
-  def sessionActionBuilder: SessionActionBuilder[SessionRequest, AnyContent]
-  def orgActionBuilder: OrgActionBuilder[OrgRequest, AnyContent]
-  def identifiedOrgActionBuilder: IdentifiedOrgActionBuilder[IdentifiedOrgRequest, AnyContent]
-  def sessionOrgActionBuilder: SessionOrgActionBuilder[SessionOrgRequest, AnyContent]
-  def identifiedCookieActionBuilder: IdentifiedCookieActionBuilder[IdentifiedRequest, AnyContent]
+  def anonymousActionBuilder: AnonymousActionBuilder
+  def identifiedActionBuilder: IdentifiedActionBuilder
+  def sessionActionBuilder: SessionActionBuilder
+  def orgActionBuilder: OrgActionBuilder
+  def identifiedOrgActionBuilder: IdentifiedOrgActionBuilder
+  def sessionOrgActionBuilder: SessionOrgActionBuilder
+  def identifiedCookieActionBuilder: IdentifiedCookieActionBuilder
 }
 
 case class FlowDefaultControllerComponents @Inject() (
-  anonymousActionBuilder: AnonymousDefaultActionBuilder,
-  identifiedActionBuilder: IdentifiedDefaultActionBuilder,
-  sessionActionBuilder: SessionDefaultActionBuilder,
-  orgActionBuilder: OrgDefaultActionBuilder,
-  identifiedOrgActionBuilder: IdentifiedOrgDefaultActionBuilder,
-  sessionOrgActionBuilder: SessionOrgDefaultActionBuilder,
-  identifiedCookieActionBuilder: IdentifiedCookieDefaultActionBuilder
+  anonymousActionBuilder: AnonymousActionBuilder,
+  identifiedActionBuilder: IdentifiedActionBuilder,
+  sessionActionBuilder: SessionActionBuilder,
+  orgActionBuilder: OrgActionBuilder,
+  identifiedOrgActionBuilder: IdentifiedOrgActionBuilder,
+  sessionOrgActionBuilder: SessionOrgActionBuilder,
+  identifiedCookieActionBuilder: IdentifiedCookieActionBuilder
 ) extends FlowControllerComponents
 
-// DI
+// Used to be DI
+@deprecated("This module does not do anything any more. Please remove it from your bindings.", since = "0.4.39")
 class FlowControllerComponentsModule extends Module {
-  def bindings(env: Environment, conf: Configuration) = {
-    Seq(
-      bind[FlowControllerComponents].to[FlowDefaultControllerComponents],
-      bind[AnonymousDefaultActionBuilder].to[AnonymousDefaultActionBuilderImpl],
-      bind[IdentifiedDefaultActionBuilder].to[IdentifiedDefaultActionBuilderImpl],
-      bind[SessionDefaultActionBuilder].to[SessionDefaultActionBuilderImpl],
-      bind[OrgDefaultActionBuilder].to[OrgDefaultActionBuilderImpl],
-      bind[IdentifiedOrgDefaultActionBuilder].to[IdentifiedOrgDefaultActionBuilderImpl],
-      bind[SessionOrgDefaultActionBuilder].to[SessionOrgDefaultActionBuilderImpl],
-      bind[IdentifiedCookieDefaultActionBuilder].to[IdentifiedCookieDefaultActionBuilderImpl]
-    )
-  }
+  def bindings(env: Environment, conf: Configuration) = Seq.empty
 }
 
 // Anonymous
-trait AnonymousActionBuilder[+R[_], B] extends ActionBuilder[R, B]
+class AnonymousActionBuilder @Inject() (val parser: BodyParsers.Default, val config: Config)(implicit val executionContext: ExecutionContext)
+  extends ActionBuilder[AnonymousRequest, AnyContent] with FlowActionInvokeBlockHelper {
 
-trait AnonymousDefaultActionBuilder extends AnonymousActionBuilder[AnonymousRequest, AnyContent]
-object AnonymousDefaultActionBuilder {
-  def apply(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext): AnonymousDefaultActionBuilder =
-    new AnonymousDefaultActionBuilderImpl(parser, config)
-}
-
-class AnonymousDefaultActionBuilderImpl(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext)
-  extends AnonymousActionBuilderImpl(parser, config) with AnonymousDefaultActionBuilder {
-  @Inject def this(parser: BodyParsers.Default, config: Config)(implicit ec: ExecutionContext) = this(parser: BodyParser[AnyContent], config: Config)
-}
-
-class AnonymousActionBuilderImpl[B](val parser: BodyParser[B], val config: Config)(implicit val executionContext: ExecutionContext)
-  extends AnonymousActionBuilder[AnonymousRequest, B] with FlowActionInvokeBlockHelper {
   def invokeBlock[A](request: Request[A], block: (AnonymousRequest[A]) => Future[Result]): Future[Result] = {
     val ad = auth(request.headers)(AuthData.Anonymous.fromMap).getOrElse {
       // Create an empty header here so at least requestId tracking can start
@@ -99,136 +75,64 @@ class AnonymousActionBuilderImpl[B](val parser: BodyParser[B], val config: Confi
 }
 
 // Identified
-trait IdentifiedActionBuilder[+R[_], B] extends ActionBuilder[R, B]
+class IdentifiedActionBuilder @Inject() (val parser: BodyParsers.Default, val config: Config)(implicit val executionContext: ExecutionContext)
+  extends ActionBuilder[IdentifiedRequest, AnyContent] with FlowActionInvokeBlockHelper {
 
-trait IdentifiedDefaultActionBuilder extends IdentifiedActionBuilder[IdentifiedRequest, AnyContent]
-object IdentifiedDefaultActionBuilder {
-  def apply(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext): IdentifiedDefaultActionBuilder =
-    new IdentifiedDefaultActionBuilderImpl(parser, config)
-}
-
-class IdentifiedDefaultActionBuilderImpl(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext)
-  extends IdentifiedActionBuilderImpl(parser, config) with IdentifiedDefaultActionBuilder {
-  @Inject def this(parser: BodyParsers.Default, config: Config)(implicit ec: ExecutionContext) = this(parser: BodyParser[AnyContent], config: Config)
-}
-
-class IdentifiedActionBuilderImpl[B](val parser: BodyParser[B], val config: Config)(implicit val executionContext: ExecutionContext)
-  extends IdentifiedActionBuilder[IdentifiedRequest, B] with FlowActionInvokeBlockHelper {
-  override def invokeBlock[A](request: Request[A], block: (IdentifiedRequest[A]) => Future[Result]): Future[Result] =
+  def invokeBlock[A](request: Request[A], block: (IdentifiedRequest[A]) => Future[Result]): Future[Result] =
     auth(request.headers)(AuthData.Identified.fromMap) match {
       case None => Future.successful(unauthorized(request))
       case Some(ad) => block(new IdentifiedRequest(ad, request))
-  }
+    }
 }
 
 // Session
-trait SessionActionBuilder[+R[_], B] extends ActionBuilder[R, B]
+class SessionActionBuilder @Inject() (val parser: BodyParsers.Default, val config: Config)(implicit val executionContext: ExecutionContext)
+  extends ActionBuilder[SessionRequest, AnyContent] with FlowActionInvokeBlockHelper {
 
-trait SessionDefaultActionBuilder extends SessionActionBuilder[SessionRequest, AnyContent]
-object SessionDefaultActionBuilder {
-  def apply(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext): SessionDefaultActionBuilder =
-    new SessionDefaultActionBuilderImpl(parser, config)
-}
-
-class SessionDefaultActionBuilderImpl(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext)
-  extends SessionActionBuilderImpl(parser, config) with SessionDefaultActionBuilder {
-  @Inject def this(parser: BodyParsers.Default, config: Config)(implicit ec: ExecutionContext) = this(parser: BodyParser[AnyContent], config: Config)
-}
-
-class SessionActionBuilderImpl[B](val parser: BodyParser[B], val config: Config)(implicit val executionContext: ExecutionContext)
-  extends SessionActionBuilder[SessionRequest, B] with FlowActionInvokeBlockHelper {
   def invokeBlock[A](request: Request[A], block: (SessionRequest[A]) => Future[Result]): Future[Result] =
     auth(request.headers)(AuthData.Session.fromMap) match {
       case None => Future.successful(unauthorized(request))
       case Some(ad) => block(new SessionRequest(ad, request))
-  }
+    }
 }
 
 // Org
-trait OrgActionBuilder[+R[_], B] extends ActionBuilder[R, B]
+class OrgActionBuilder @Inject() (val parser: BodyParsers.Default, val config: Config)(implicit val executionContext: ExecutionContext)
+  extends ActionBuilder[OrgRequest, AnyContent] with FlowActionInvokeBlockHelper {
 
-trait OrgDefaultActionBuilder extends OrgActionBuilder[OrgRequest, AnyContent]
-object OrgDefaultActionBuilder {
-  def apply(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext): OrgDefaultActionBuilder =
-    new OrgDefaultActionBuilderImpl(parser, config)
-}
-
-class OrgDefaultActionBuilderImpl(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext)
-  extends OrgActionBuilderImpl(parser, config) with OrgDefaultActionBuilder {
-  @Inject def this(parser: BodyParsers.Default, config: Config)(implicit ec: ExecutionContext) = this(parser: BodyParser[AnyContent], config: Config)
-}
-
-class OrgActionBuilderImpl[B](val parser: BodyParser[B], val config: Config)(implicit val executionContext: ExecutionContext)
-  extends OrgActionBuilder[OrgRequest, B] with FlowActionInvokeBlockHelper {
   def invokeBlock[A](request: Request[A], block: (OrgRequest[A]) => Future[Result]): Future[Result] =
     auth(request.headers)(OrgAuthData.Org.fromMap) match {
       case None => Future.successful(unauthorized(request))
       case Some(ad) => block(new OrgRequest(ad, request))
-  }
+    }
 }
 
 // IdentifiedOrg
-trait IdentifiedOrgActionBuilder[+R[_], B] extends ActionBuilder[R, B]
+class IdentifiedOrgActionBuilder @Inject() (val parser: BodyParsers.Default, val config: Config)(implicit val executionContext: ExecutionContext)
+  extends ActionBuilder[IdentifiedOrgRequest, AnyContent] with FlowActionInvokeBlockHelper {
 
-trait IdentifiedOrgDefaultActionBuilder extends IdentifiedOrgActionBuilder[IdentifiedOrgRequest, AnyContent]
-object IdentifiedOrgDefaultActionBuilder {
-  def apply(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext): IdentifiedOrgDefaultActionBuilder =
-    new IdentifiedOrgDefaultActionBuilderImpl(parser, config)
-}
-
-class IdentifiedOrgDefaultActionBuilderImpl(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext)
-  extends IdentifiedOrgActionBuilderImpl(parser, config) with IdentifiedOrgDefaultActionBuilder {
-  @Inject def this(parser: BodyParsers.Default, config: Config)(implicit ec: ExecutionContext) = this(parser: BodyParser[AnyContent], config: Config)
-}
-
-class IdentifiedOrgActionBuilderImpl[B](val parser: BodyParser[B], val config: Config)(implicit val executionContext: ExecutionContext)
-  extends IdentifiedOrgActionBuilder[IdentifiedOrgRequest, B] with FlowActionInvokeBlockHelper {
   def invokeBlock[A](request: Request[A], block: (IdentifiedOrgRequest[A]) => Future[Result]): Future[Result] =
     auth(request.headers)(OrgAuthData.Identified.fromMap) match {
       case None => Future.successful(unauthorized(request))
       case Some(ad) => block(new IdentifiedOrgRequest(ad, request))
-  }
+    }
 }
 
 // SessionOrg
-trait SessionOrgActionBuilder[+R[_], B] extends ActionBuilder[R, B]
+class SessionOrgActionBuilder @Inject() (val parser: BodyParsers.Default, val config: Config)(implicit val executionContext: ExecutionContext)
+  extends ActionBuilder[SessionOrgRequest, AnyContent] with FlowActionInvokeBlockHelper {
 
-trait SessionOrgDefaultActionBuilder extends SessionOrgActionBuilder[SessionOrgRequest, AnyContent]
-object SessionOrgDefaultActionBuilder {
-  def apply(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext): SessionOrgDefaultActionBuilder =
-    new SessionOrgDefaultActionBuilderImpl(parser, config)
-}
-
-class SessionOrgDefaultActionBuilderImpl(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext)
-  extends SessionOrgActionBuilderImpl(parser, config) with SessionOrgDefaultActionBuilder {
-  @Inject def this(parser: BodyParsers.Default, config: Config)(implicit ec: ExecutionContext) = this(parser: BodyParser[AnyContent], config: Config)
-}
-
-class SessionOrgActionBuilderImpl[B](val parser: BodyParser[B], val config: Config)(implicit val executionContext: ExecutionContext)
-  extends SessionOrgActionBuilder[SessionOrgRequest, B] with FlowActionInvokeBlockHelper {
   def invokeBlock[A](request: Request[A], block: (SessionOrgRequest[A]) => Future[Result]): Future[Result] =
     auth(request.headers)(OrgAuthData.Session.fromMap) match {
       case None => Future.successful (unauthorized(request))
       case Some(ad) => block(new SessionOrgRequest(ad, request))
-  }
+    }
 }
 
 // IdentifiedCookie
-trait IdentifiedCookieActionBuilder[+R[_], B] extends ActionBuilder[R, B]
+class IdentifiedCookieActionBuilder @Inject() (val parser: BodyParsers.Default, val config: Config)(implicit val executionContext: ExecutionContext)
+  extends ActionBuilder[IdentifiedRequest, AnyContent] with FlowActionInvokeBlockHelper {
 
-trait IdentifiedCookieDefaultActionBuilder extends IdentifiedCookieActionBuilder[IdentifiedRequest, AnyContent]
-object IdentifiedCookieDefaultActionBuilder {
-  def apply(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext): IdentifiedCookieDefaultActionBuilder =
-    new IdentifiedCookieDefaultActionBuilderImpl(parser, config)
-}
-
-class IdentifiedCookieDefaultActionBuilderImpl(parser: BodyParser[AnyContent], config: Config)(implicit ec: ExecutionContext)
-  extends IdentifiedCookieActionBuilderImpl(parser, config) with IdentifiedCookieDefaultActionBuilder {
-  @Inject def this(parser: BodyParsers.Default, config: Config)(implicit ec: ExecutionContext) = this(parser: BodyParser[AnyContent], config: Config)
-}
-
-class IdentifiedCookieActionBuilderImpl[B](val parser: BodyParser[B], val config: Config)(implicit val executionContext: ExecutionContext)
-  extends IdentifiedCookieActionBuilder[IdentifiedRequest, B] with FlowActionInvokeBlockHelper {
   def invokeBlock[A](request: Request[A], block: (IdentifiedRequest[A]) => Future[Result]): Future[Result] =
     request.session.get(IdentifiedCookie.UserKey) match {
       case None => Future.successful(unauthorized(request))

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val root = project
     libraryDependencies ++= Seq(
       ws,
       filters,
+      guice,
       specs2 % Test,
       "com.jason-goodwin" %% "authentikat-jwt" % "0.4.5",
       "com.ning" % "async-http-client" % "1.9.40",

--- a/test/io/flow/play/controllers/FlowControllerSpec.scala
+++ b/test/io/flow/play/controllers/FlowControllerSpec.scala
@@ -32,4 +32,4 @@ class FlowControllerImpl @Inject() (
   val config: Config,
   val flowControllerComponents: FlowControllerComponents,
   val controllerComponents: ControllerComponents
-) extends FlowController {}
+) extends FlowController

--- a/test/io/flow/play/controllers/FlowControllerSpec.scala
+++ b/test/io/flow/play/controllers/FlowControllerSpec.scala
@@ -16,12 +16,6 @@ class FlowControllerSpec extends FlowPlaySpec {
       .bindings(new ConfigModule)
       .build()
 
-  class FlowControllerImpl @Inject() (
-    val config: Config,
-    val flowControllerComponents: FlowControllerComponents,
-    val controllerComponents: ControllerComponents
-  ) extends FlowController {}
-
   "FlowController" should {
 
     "be instantiated" in {
@@ -33,3 +27,9 @@ class FlowControllerSpec extends FlowPlaySpec {
   }
 
 }
+
+class FlowControllerImpl @Inject() (
+  val config: Config,
+  val flowControllerComponents: FlowControllerComponents,
+  val controllerComponents: ControllerComponents
+) extends FlowController {}

--- a/test/io/flow/play/controllers/FlowControllerSpec.scala
+++ b/test/io/flow/play/controllers/FlowControllerSpec.scala
@@ -1,0 +1,35 @@
+package io.flow.play.controllers
+
+import javax.inject.Inject
+
+import io.flow.play.clients.ConfigModule
+import io.flow.play.util.Config
+import io.flow.test.utils.FlowPlaySpec
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.ControllerComponents
+
+class FlowControllerSpec extends FlowPlaySpec {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .bindings(new ConfigModule)
+      .build()
+
+  class FlowControllerImpl @Inject() (
+    val config: Config,
+    val flowControllerComponents: FlowControllerComponents,
+    val controllerComponents: ControllerComponents
+  ) extends FlowController {}
+
+  "FlowController" should {
+
+    "be instantiated" in {
+      val controller = init[FlowControllerImpl]
+      controller must not be null
+      controller.flowControllerComponents must not be null
+    }
+
+  }
+
+}


### PR DESCRIPTION
This change is a proposal to simplify `FlowController`.

 1 - simplify all `ActionBuilder` classes
 2 - simplify module since constructors are provided
 3 - entirely remove `FlowControllerComponentsModule` (made empty and deprecated)

