### PR TITLE
Add secure id generator

### DIFF
--- a/app/io/flow/play/util/SecureIdGenerator.scala
+++ b/app/io/flow/play/util/SecureIdGenerator.scala
@@ -34,11 +34,11 @@ case class SecureIdGenerator(
   assert(!BadWords.contains(prefix), s"prefix[$prefix] is on the black list and cannot be used")
 
 
-  private[this] val TokenLength = 64 - prefix.length
+  private[this] val tokenLength = 64 - prefix.length
   private[this] val random = Random()
 
   def randomId(): String = {
-    prefix + random.alphaNumeric(TokenLength)
+    prefix + random.alphaNumeric(tokenLength)
   }
 
 }

--- a/app/io/flow/play/util/SecureIdGenerator.scala
+++ b/app/io/flow/play/util/SecureIdGenerator.scala
@@ -1,0 +1,44 @@
+package io.flow.play.util
+
+object SecureIdGenerator {
+  val MinPrefixLength = 3
+  // M and W are both 3 characters in the pager code alphabet.
+  val MaxPrefixLength = 6
+}
+
+/**
+  * Generates a new, cryptographically secure, unique ID for a resource.
+  * Main feature is to prefix the unique id with a three character identifer to
+  * understand how the ID is used (e.g. 'F61').
+  *
+  * Secure id prefixes use the following format:
+  *   https://github.com/flowcommerce/standards/blob/master/Naming.md
+  * If adding a new prefix, create a pull request to update the `Flow Prefixes`
+  * section at the bottom of the document so others are aware.
+  *
+  * @param prefix Global prefix to identify the type of resource for which you
+  *         are generating an ID. Must be 3 characters, uppercase.
+  */
+case class SecureIdGenerator(
+  prefix: String
+) {
+  assert(prefix.trim == prefix, s"prefix[$prefix] must be trimmed")
+  assert(prefix.toUpperCase == prefix, s"prefix[$prefix] must be in upper case")
+  assert(prefix.startsWith("F"), s"prefix[$prefix] must begin with the letter 'F'")
+  assert(
+    prefix.length >= SecureIdGenerator.MinPrefixLength &&
+    prefix.length <= SecureIdGenerator.MaxPrefixLength,
+    s"prefix[$prefix] must be between " +
+    s"${SecureIdGenerator.MinPrefixLength} and ${SecureIdGenerator.MaxPrefixLength} characters"
+  )
+  assert(!BadWords.contains(prefix), s"prefix[$prefix] is on the black list and cannot be used")
+
+
+  private[this] val TokenLength = 64 - prefix.length
+  private[this] val random = Random()
+
+  def randomId(): String = {
+    prefix + random.alphaNumeric(TokenLength)
+  }
+
+}

--- a/app/io/flow/play/util/SecureIdGenerator.scala
+++ b/app/io/flow/play/util/SecureIdGenerator.scala
@@ -17,7 +17,7 @@ object SecureIdGenerator {
   * section at the bottom of the document so others are aware.
   *
   * @param prefix Global prefix to identify the type of resource for which you
-  *         are generating an ID. Must be 3 characters, uppercase.
+  *         are generating an ID. Must be 3-6 characters, uppercase.
   */
 case class SecureIdGenerator(
   prefix: String

--- a/test/io/flow/play/util/SecureIdGeneratorSpec.scala
+++ b/test/io/flow/play/util/SecureIdGeneratorSpec.scala
@@ -1,0 +1,47 @@
+package io.flow.play.util
+
+class SecureIdGeneratorSpec extends LibPlaySpec {
+
+  "prefix must be between 3 - 6 characters" in {
+    intercept[AssertionError] {
+      SecureIdGenerator("FO")
+    }.getMessage must be("assertion failed: prefix[FO] must be between 3 and 6 characters")
+
+    intercept[AssertionError] {
+      SecureIdGenerator("FOFOFOFO")
+    }.getMessage must be("assertion failed: prefix[FOFOFOFO] must be between 3 and 6 characters")
+  }
+
+  "prefix must be upper case" in {
+    intercept[AssertionError] {
+      SecureIdGenerator("foo")
+    }.getMessage must be("assertion failed: prefix[foo] must be in upper case")
+  }
+
+  "prefix must be trimmed" in {
+    intercept[AssertionError] {
+      SecureIdGenerator("  FOO  ")
+    }.getMessage must be("assertion failed: prefix[  FOO  ] must be trimmed")
+  }
+
+  "prefix is not on black list" in {
+    intercept[AssertionError] {
+      SecureIdGenerator("FECK")
+    }.getMessage must be("assertion failed: prefix[FECK] is on the black list and cannot be used")
+  }
+
+  "randomId must start with prefix" in {
+    val generator = SecureIdGenerator("F12")
+    val id = generator.randomId()
+    id.startsWith("F12") must be(true)
+  }
+
+  "randomId must be 64 characters long" in {
+    val generator = SecureIdGenerator("F12")
+    val num = 10000
+    val ids = 1.to(num).map { _ => generator.randomId() }
+    ids.size must be(num)
+    ids.distinct.size must be(ids.size)
+    ids.foreach { _.length must equal(64) }
+  }
+}


### PR DESCRIPTION
This PR adds a secure id generator, ideally so it can be used in hack DAO generator for models requiring a cryptographically secure token.