### PR TITLE
Add setter injection for FlowControllerComponents

### DIFF
--- a/app/io/flow/play/controllers/FlowController.scala
+++ b/app/io/flow/play/controllers/FlowController.scala
@@ -10,35 +10,17 @@ import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait InjectedFlowController extends InjectedController {
-  private[this] var _flowControllerComponents: FlowControllerComponents = _
-
-  protected def flowControllerComponents: FlowControllerComponents =
-    if (_flowControllerComponents == null) fallbackFlowControllerComponents else _flowControllerComponents
-
-  /**
-    * Call this method to set the [[FlowControllerComponents]] instance.
-    */
-  @Inject
-  def setFlowControllerComponents(components: FlowControllerComponents): Unit = {
-    _flowControllerComponents = components
-  }
-  /**
-    * Defines fallback components to use in case setFlowControllerComponents has not been called.
-    */
-  protected def fallbackFlowControllerComponents: FlowControllerComponents = {
-    throw new NoSuchElementException(
-      "FlowControllerComponents not set! Call setFlowControllerComponents or create the instance with dependency injection.")
-  }
-}
-
-/*
+/**
   USAGE:
   --------------------------------------------------------------
-  1) Just extend your Play controller with FlowController
-  2) Profit!
+  1) Extend play controller with FlowController
+  2) In controller's constructor provide the following for DI
+      val controllerComponents: ControllerComponents,
+      val flowControllerComponents: FlowControllerComponents
+
+  If you want the components to be set automatically by DI, you can extend [[InjectedFlowController]] instead.
 */
-trait FlowController extends InjectedFlowController with FlowControllerHelpers {
+trait FlowController extends BaseController with FlowControllerHelpers {
   protected def flowControllerComponents: FlowControllerComponents
 
   def Anonymous: AnonymousActionBuilder = flowControllerComponents.anonymousActionBuilder

--- a/app/io/flow/play/controllers/InjectedFlowController.scala
+++ b/app/io/flow/play/controllers/InjectedFlowController.scala
@@ -1,0 +1,32 @@
+package io.flow.play.controllers
+
+import javax.inject.Inject
+
+import play.api.mvc.InjectedController
+
+/**
+  * An alternative of [[FlowController]] that relies on dependency injection to get the component instances.
+  * Implementation adapted from [[play.api.mvc.InjectedController]].
+  * */
+trait InjectedFlowController extends FlowController with InjectedController {
+  private[this] var _flowControllerComponents: FlowControllerComponents = _
+
+  protected def flowControllerComponents: FlowControllerComponents =
+    if (_flowControllerComponents == null) fallbackFlowControllerComponents else _flowControllerComponents
+
+  /**
+    * Call this method to set the [[FlowControllerComponents]] instance.
+    */
+  @Inject
+  def setFlowControllerComponents(components: FlowControllerComponents): Unit = {
+    _flowControllerComponents = components
+  }
+
+  /**
+    * Defines fallback components to use in case setFlowControllerComponents has not been called.
+    */
+  protected def fallbackFlowControllerComponents: FlowControllerComponents = {
+    throw new NoSuchElementException(
+      "FlowControllerComponents not set! Call setFlowControllerComponents or create the instance with dependency injection.")
+  }
+}

--- a/test/io/flow/play/controllers/FlowControllerSpec.scala
+++ b/test/io/flow/play/controllers/FlowControllerSpec.scala
@@ -1,13 +1,9 @@
 package io.flow.play.controllers
 
-import javax.inject.Inject
-
 import io.flow.play.clients.ConfigModule
-import io.flow.play.util.Config
 import io.flow.test.utils.FlowPlaySpec
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.mvc.ControllerComponents
 
 class FlowControllerSpec extends FlowPlaySpec {
 
@@ -21,7 +17,7 @@ class FlowControllerSpec extends FlowPlaySpec {
     "be instantiated" in {
       val controller = init[FlowControllerImpl]
       controller must not be null
-      controller.flowControllerComponents must not be null
+      controller.Identified must not be null
     }
 
   }
@@ -29,8 +25,4 @@ class FlowControllerSpec extends FlowPlaySpec {
 }
 
 // Mimic usual controller
-class FlowControllerImpl @Inject() (
-  val config: Config,
-  val flowControllerComponents: FlowControllerComponents,
-  val controllerComponents: ControllerComponents
-) extends FlowController
+class FlowControllerImpl extends FlowController

--- a/test/io/flow/play/controllers/FlowControllerSpec.scala
+++ b/test/io/flow/play/controllers/FlowControllerSpec.scala
@@ -1,9 +1,12 @@
 package io.flow.play.controllers
 
+import javax.inject.Inject
+
 import io.flow.play.clients.ConfigModule
 import io.flow.test.utils.FlowPlaySpec
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.ControllerComponents
 
 class FlowControllerSpec extends FlowPlaySpec {
 
@@ -17,7 +20,8 @@ class FlowControllerSpec extends FlowPlaySpec {
     "be instantiated" in {
       val controller = init[FlowControllerImpl]
       controller must not be null
-      controller.Identified must not be null
+      controller.flowControllerComponents must not be null
+      controller.controllerComponents must not be null
     }
 
   }
@@ -25,4 +29,7 @@ class FlowControllerSpec extends FlowPlaySpec {
 }
 
 // Mimic usual controller
-class FlowControllerImpl extends FlowController
+class FlowControllerImpl @Inject() (
+  val flowControllerComponents: FlowControllerComponents,
+  val controllerComponents: ControllerComponents
+) extends FlowController

--- a/test/io/flow/play/controllers/InjectedFlowControllerSpec.scala
+++ b/test/io/flow/play/controllers/InjectedFlowControllerSpec.scala
@@ -1,0 +1,28 @@
+package io.flow.play.controllers
+
+import io.flow.play.clients.ConfigModule
+import io.flow.test.utils.FlowPlaySpec
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+
+class InjectedFlowControllerSpec extends FlowPlaySpec {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .bindings(new ConfigModule)
+      .build()
+
+  "InjectedFlowController" should {
+
+    "be instantiated" in {
+      val controller = init[InjectedFlowControllerImpl]
+      controller must not be null
+      controller.Anonymous must not be null
+      controller.Action must not be null
+    }
+  }
+}
+
+// Mimic usual controller
+class InjectedFlowControllerImpl extends InjectedFlowController
+


### PR DESCRIPTION
Highlights:
- `Config` isn't needed to construct a FlowController, so it's removed
- `extends BaseController with BaseControllerHelpers` is redundant, because `BaseController` extends `BaseControllerHelpers` itself, so I removed the extension of `BaseControllerHelpers`
- `controllerComponents` are now set by `InjectedController` from Play
- `flowControllerComponents` are now set by the brand new `InjectedFlowController`

Use case:

Before:

```scala
class FlowControllerImpl @Inject() (
  val config: Config,
  val flowControllerComponents: FlowControllerComponents,
  val controllerComponents: ControllerComponents
) extends FlowController
```

After:
```scala
class FlowControllerImpl extends InjectedFlowController
```

Implements #198 