### PR TITLE
Add a filename friendly DateTime format

### DIFF
--- a/app/io/flow/play/util/DateHelper.scala
+++ b/app/io/flow/play/util/DateHelper.scala
@@ -38,6 +38,10 @@ trait DateFormats {
     dateTime.map(consoleLongDateTime(_)).getOrElse(default)
   }
 
+  def filenameDateTime(dateTime: DateTime): String
+  def filenameDateTime(dateTime: Option[DateTime], default: String = "N/A"): String =
+    dateTime.map(filenameDateTime).getOrElse(default)
+
 }
 
 /**
@@ -49,6 +53,8 @@ object DateHelper extends DateFormats {
   implicit def dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
 
   val CopyrightStartYear = 2016
+
+  val FilenameDateTimeFormatter = DateTimeFormat.forPattern("yyyyMMdd.HHmmss.SSS")
 
   val EasternTimezone = DateTimeZone.forID("America/New_York")
   private[this] val Default = DateHelper(EasternTimezone)
@@ -65,6 +71,11 @@ object DateHelper extends DateFormats {
 
   override def consoleLongDateTime(dateTime: DateTime) = Default.consoleLongDateTime(dateTime)
 
+  /**
+    * Returns a filename friendly datetime string
+    * The returned string respects the timezone of the datetime and is not part of the string itself
+    */
+  override def filenameDateTime(dateTime: DateTime): String = DateHelper(dateTime.getZone).filenameDateTime(dateTime)
 
   /**
     * Turns "1" into "01", leaves "12" as "12"
@@ -164,5 +175,8 @@ case class DateHelper(
   ): String = {
     DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss z").withZone(timezone).print(dateTime)
   }
+
+  override def filenameDateTime(dateTime: DateTime): String =
+    DateHelper.FilenameDateTimeFormatter.withZone(timezone).print(dateTime)
 
 }

--- a/test/io/flow/play/util/DateHelperSpec.scala
+++ b/test/io/flow/play/util/DateHelperSpec.scala
@@ -74,7 +74,7 @@ class DateHelperSpec extends WordSpec with MustMatchers {
     DateHelper.filenameDateTime(dtNy) mustBe "20160101.082618.794"
     DateHelper.filenameDateTime(dtUtc) mustBe "20160101.132618.794"
 
-    DateHelper.filenameDateTime(Some(jan1), "-") mustBe "20160101.082618.794"
+    DateHelper.filenameDateTime(Some(jan1.withZone(DateTimeZone.forID("America/New_York"))), "-") mustBe "20160101.082618.794"
     DateHelper.filenameDateTime(None) mustBe "N/A"
     DateHelper.filenameDateTime(None, "-") mustBe "-"
   }

--- a/test/io/flow/play/util/DateHelperSpec.scala
+++ b/test/io/flow/play/util/DateHelperSpec.scala
@@ -1,11 +1,10 @@
 package io.flow.play.util
 
-import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-import org.scalatestplus.play._
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatest.{MustMatchers, WordSpec}
 
-class DateHelperSpec extends LibPlaySpec {
+class DateHelperSpec extends WordSpec with MustMatchers {
 
   val jan1 = dateTimeParser.parseDateTime("2016-01-01T08:26:18.794-05:00")
 
@@ -67,6 +66,17 @@ class DateHelperSpec extends LibPlaySpec {
   "copyrightYear" in {
     val value = DateHelper.copyrightYears
     Seq("2016", s"2016 - ${DateHelper.currentYear}").contains(value) mustBe(true)
+  }
+
+  "filenameDateTime" in {
+    val dtNy = jan1.withZone(DateTimeZone.forID("America/New_York"))
+    val dtUtc = jan1.withZone(DateTimeZone.UTC)
+    DateHelper.filenameDateTime(dtNy) mustBe "20160101.082618.794"
+    DateHelper.filenameDateTime(dtUtc) mustBe "20160101.132618.794"
+
+    DateHelper.filenameDateTime(Some(jan1), "-") mustBe "20160101.082618.794"
+    DateHelper.filenameDateTime(None) mustBe "N/A"
+    DateHelper.filenameDateTime(None, "-") mustBe "-"
   }
 
   "implicit ordering" in {


### PR DESCRIPTION
Format is `"yyyyMMdd.HHmmss.SSS"`. 

Contrary to existing methods, it does respect the timezone of the datetime. This is the case so that a daily 9AM in Paris always outputs "yyyyMMdd.090000.000" every day of the year. Note that the tz itself is not part of the output.