### PR TITLE
depend on logstash-logback so that we can log json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val root = project
       "com.jason-goodwin" %% "authentikat-jwt" % "0.4.5",
       "com.ning" % "async-http-client" % "1.9.40",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
-      "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
+      "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
       specs2 % Test
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val root = project
       "com.jason-goodwin" %% "authentikat-jwt" % "0.4.5",
       "com.ning" % "async-http-client" % "1.9.40",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
+      "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
       specs2 % Test
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",


### PR DESCRIPTION
We are adding this just so that every service depends on this lib. This will allow us to log JSON by changing `logback.xml` [like so](https://github.com/flowcommerce/lib-play/blob/logging-play26/conf/logback.xml). One benefit is that entire stack traces will be in the single JSON blob