### PR TITLE
Add a classes for proxying actor messages across SQS between services

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,58 @@ leaking information).
        Default implementation uses user token through basic
        authorization
 
+## SQS Actor Proxy
+
+When splitting out background processing, it became apparent that we needed to have a way
+to send messages from an API service to actors running in the background processing jobs service.
+
+With minimal amount of refactoring required, we can do this by binding a proxy actor to the original
+actor name in the API service, which send all messages it gets over SQS to a receiver in the jobs service.
+The receiver will forward all messages received on its SQS queue to the original actor that now lives in
+the jobs service.
+
+To use this, you need to add the `ActorProxyGuiceSupport` to your Actor guice module. Then you can bind your
+proxy sender to the original actor name, where `@Named("test-actor") actorRef: ActorRef` is used.
+
+```
+- bindActor[TestActor]("test-actor")
++ bindActorProxySender("test-actor", ReactiveActorProxySerde)
+```
+
+Then in your jobs service you can bind your original actor with a proxy receiver.
+
+```
++ bindActor[TestActor]("test-actor")
++ bindActorProxyReceiver(
++   name = "test-actor-receiver",
++   proxiedName = "test-actor",
++   serde = ReactiveActorProxySerde
++ )
+```
+
+Once that is done, you can send messages as you normally would, as long as your `ProxySerde` passed
+to your sender and receiver, knows how to serialize and deserialize the messages.
+
+```
+class TestActorCaller @Inject() (@Named("test-actor") actor: ActorRef) extends Actor with ActorLogging {
+  override def receive: Receive = {
+    case Tick =>
+      // the following really send the message to the proxy we have bound to "test-actor"
+      actor ! ReactiveActor.Messages.Changed
+  }
+}
+
+
+class TestActor extends Actor with ActorLogging {
+  override def receive: Receive = {
+    case ReactiveActor.Messages.Changed => log.info("RECEIVED TEST ACTOR CHANGED MESSAGE!")
+  }
+}
+```
+
+_NOTE: The sender and receiver will use the service name and the proxied receiver actor name to create an SQS queue_
+
+
 ## Publishing a new version
 
     go run release.go

--- a/app/io/flow/play/actors/proxy/ActorProxyGuiceSupport.scala
+++ b/app/io/flow/play/actors/proxy/ActorProxyGuiceSupport.scala
@@ -1,0 +1,72 @@
+package io.flow.play.actors.proxy
+
+import java.lang.reflect.Method
+
+import akka.actor.{ActorRef, ActorSystem}
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.google.inject.name.Names
+import com.google.inject.util.Providers
+import com.google.inject.{AbstractModule, Binder}
+import javax.inject.{Inject, Provider}
+import play.api.inject.{BindingKey, Injector}
+import play.api.libs.concurrent.AkkaGuiceSupport
+
+trait ActorProxyGuiceSupport {
+  self: AbstractModule with AkkaGuiceSupport =>
+
+  protected val serviceName: String
+
+  private def accessBinder: Binder = {
+    val method: Method = classOf[AbstractModule].getDeclaredMethod("binder")
+    if (!method.isAccessible) {
+      method.setAccessible(true)
+    }
+    method.invoke(this).asInstanceOf[Binder]
+  }
+
+  def bindActorProxySender(name: String, serde: ProxySerde): Unit = {
+    accessBinder.bind(classOf[ActorRef])
+      .annotatedWith(Names.named(name))
+      .toProvider(Providers.guicify(new SenderProxyActorProvider(name, serde)))
+      .asEagerSingleton()
+  }
+
+  def bindActorProxyReceiver(name: String, proxiedName: String, serde: ProxySerde): Unit = {
+    accessBinder.bind(classOf[ActorRef])
+      .annotatedWith(Names.named(name))
+      .toProvider(Providers.guicify(new ReceiverProxyActorProvider(name, proxiedName, serde)))
+      .asEagerSingleton()
+  }
+
+  private class SenderProxyActorProvider(name: String, serde: ProxySerde) extends Provider[ActorRef] {
+
+    @Inject private var actorSystem: ActorSystem = _
+    @Inject private var injector: Injector = _
+    lazy val get = {
+      val sqs = injector.instanceOf(classOf[AmazonSQSAsync])
+      actorSystem.actorOf(SQSProxyActor.senderProps(
+        receiverActorName = name,
+        serviceName = serviceName,
+        sqs = sqs,
+        serde = serde
+      ), name)
+    }
+  }
+
+  private class ReceiverProxyActorProvider(name: String, proxiedName: String, serde: ProxySerde) extends Provider[ActorRef] {
+
+    @Inject private var actorSystem: ActorSystem = _
+    @Inject private var injector: Injector = _
+    lazy val get = {
+      val proxiedActorRef = injector.instanceOf(BindingKey(classOf[ActorRef]).qualifiedWith(proxiedName))
+      val sqs = injector.instanceOf(classOf[AmazonSQSAsync])
+      actorSystem.actorOf(SQSProxyActor.receiverProps(
+        serviceName = serviceName,
+        receiver = proxiedActorRef,
+        sqs = sqs,
+        serde = serde
+      ), name)
+    }
+  }
+
+}

--- a/app/io/flow/play/actors/proxy/ProxySerde.scala
+++ b/app/io/flow/play/actors/proxy/ProxySerde.scala
@@ -1,0 +1,6 @@
+package io.flow.play.actors.proxy
+
+trait ProxySerde {
+  def serialize(msg: Any): String
+  def deserialise(msg: String, msgType: String): Any
+}

--- a/app/io/flow/play/actors/proxy/SQSProxyActor.scala
+++ b/app/io/flow/play/actors/proxy/SQSProxyActor.scala
@@ -1,0 +1,27 @@
+package io.flow.play.actors.proxy
+
+import akka.actor.{ActorRef, Props}
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import play.api.libs.json.{Json, OFormat}
+
+object ProxyEnvelope {
+  implicit val format: OFormat[ProxyEnvelope] = Json.format[ProxyEnvelope]
+}
+case class ProxyEnvelope(senderActorPath: String, messageType: String, message: String)
+
+object SQSProxyActor {
+
+  def senderProps(receiverActorName: String, serviceName: String, sqs: AmazonSQSAsync, serde: ProxySerde): Props = {
+    Props(new SQSSenderProxyActor(receiverActorName, sqs, serviceName, serde))
+  }
+
+  def receiverProps(serviceName: String, receiver: ActorRef, sqs: AmazonSQSAsync, serde: ProxySerde): Props = {
+    Props(new SQSReceiverProxyActor(receiver, sqs, serviceName, serde))
+  }
+
+  private[proxy] def generateQueueUrl(receiverActorName: String, serviceName: String, sqs: AmazonSQSAsync): String = {
+    val queueName = s"$serviceName-$receiverActorName"
+    sqs.createQueue(queueName).getQueueUrl
+  }
+
+}

--- a/app/io/flow/play/actors/proxy/SQSReceiverProxyActor.scala
+++ b/app/io/flow/play/actors/proxy/SQSReceiverProxyActor.scala
@@ -1,0 +1,38 @@
+package io.flow.play.actors.proxy
+
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
+import akka.stream.alpakka.sqs.{MessageAction, SqsSourceSettings}
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import io.flow.akka.SafeReceive
+import play.api.libs.json.Json
+
+class SQSReceiverProxyActor(receiver: ActorRef, sqs: AmazonSQSAsync, serviceName: String, serde: ProxySerde) extends Actor with ActorLogging {
+  // This binds the created stream to this actors lifecycle, (i.e. actor dies, stream dies)
+  private implicit val mat: ActorMaterializer = ActorMaterializer()
+  private implicit val sqsClient: AmazonSQSAsync = sqs
+  private val QueueUrl = SQSProxyActor.generateQueueUrl(receiver.path.name, serviceName, sqs)
+
+  private val Source = SqsSource(
+    QueueUrl,
+    settings = SqsSourceSettings(
+      waitTimeSeconds = 20,
+      maxBufferSize = 100,
+      maxBatchSize = 10
+    )
+  )(sqs)
+
+  override def preStart(): Unit = {
+    Source.map { msg =>
+      val envelope = Json.parse(msg.getBody).as[ProxyEnvelope]
+      receiver ! serde.deserialise(envelope.message, envelope.messageType)
+      (msg, MessageAction.Delete)
+    }.runWith(SqsAckSink(QueueUrl))
+  }
+
+  override def receive: Receive = SafeReceive {
+    case msg => log.warning(s"UNKNOWN SQS message received: $msg")
+  }
+
+}

--- a/app/io/flow/play/actors/proxy/SQSSenderProxyActor.scala
+++ b/app/io/flow/play/actors/proxy/SQSSenderProxyActor.scala
@@ -1,0 +1,22 @@
+package io.flow.play.actors.proxy
+
+import akka.actor.{Actor, ActorLogging}
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.SendMessageRequest
+import io.flow.akka.SafeReceive
+import play.api.libs.json.Json
+
+class SQSSenderProxyActor(receiverActorName: String, sqs: AmazonSQSAsync, serviceName: String, serde: ProxySerde) extends Actor with ActorLogging {
+
+  private val QueueUrl = SQSProxyActor.generateQueueUrl(receiverActorName, serviceName, sqs)
+
+  override def receive: Receive = SafeReceive {
+    case msg => sqs.sendMessage(new SendMessageRequest()
+      .withQueueUrl(QueueUrl)
+      .withMessageBody(Json.stringify(Json.toJson(ProxyEnvelope(
+        senderActorPath = sender().path.toStringWithoutAddress,
+        messageType = msg.getClass.getName,
+        message = serde.serialize(msg)
+      )))))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,10 @@ lazy val root = project
       "io.flow" %% "lib-akka" % "0.0.3",
       "com.jason-goodwin" %% "authentikat-jwt" % "0.4.5",
       "com.ning" % "async-http-client" % "1.9.40",
+      // The following libs are Provided so dependencies are only included if io.flow.play.actors.proxy.* is used
+      "com.typesafe.akka" %% "akka-stream" % "2.5.13" % Provided,
+      "com.typesafe.akka" %% "akka-slf4j" % "2.5.13" % Provided,
+      "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "0.20" % Provided,
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "net.logstash.logback" % "logstash-logback-encoder" % "5.1",
       specs2 % Test


### PR DESCRIPTION
When splitting out background processing, it became apparent that we needed to have a way
to send messages from an API service to actors running in the background processing jobs service.

With minimal amount of refactoring required, we can do this by binding a proxy actor to the original
actor name in the API service, which send all messages it gets over SQS to a receiver in the jobs service. The receiver will forward all messages received on its SQS queue to the original actor that now lives in the jobs service.