### PR TITLE
Use apache commons to download urls

### DIFF
--- a/app/io/flow/play/util/Urls.scala
+++ b/app/io/flow/play/util/Urls.scala
@@ -1,20 +1,23 @@
 package io.flow.play.util
 
-import sys.process._
 import java.net.URL
 import java.io.File
-import scala.language.postfixOps
+import org.apache.commons.io.FileUtils
 
 object Urls {
 
   def downloadToFile(url: String, file: File): File = {
-    new URL(url) #> file !!
+    downloadToFile(new URL(url), file)
+  }
 
+  def downloadToFile(url: URL, file: File): File = {
+    FileUtils.copyURLToFile(url, file)
     file
   }
 
-  def downloadToTmpFile(url: String, prefix: String, suffix: String): File = {
-    downloadToFile(url, File.createTempFile(prefix, suffix))
+  def downloadToTmpFile(url: String, prefix: String = "download", suffix: String = "tmp"): File = {
+    val finalSuffix = if (suffix.startsWith(".")) { suffix } else { "." + suffix }
+    downloadToFile(url, File.createTempFile(prefix, finalSuffix))
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val root = project
       "io.flow" %% "lib-akka" % "0.0.3",
       "com.jason-goodwin" %% "authentikat-jwt" % "0.4.5",
       "com.ning" % "async-http-client" % "1.9.40",
+      "org.apache.commons" % "commons-io" % "1.3.2",
       // The following libs are Provided so dependencies are only included if io.flow.play.actors.proxy.* is used
       "com.typesafe.akka" %% "akka-stream" % "2.5.17" % Provided,
       "com.typesafe.akka" %% "akka-slf4j" % "2.5.13" % Provided,

--- a/test/io/flow/play/util/UrlsSpec.scala
+++ b/test/io/flow/play/util/UrlsSpec.scala
@@ -1,0 +1,18 @@
+package io.flow.play.util
+
+import java.io.File
+import java.nio.charset.Charset
+
+import org.apache.commons.io.FileUtils
+
+class UrlsSpec extends LibPlaySpec {
+
+  "downloadToTmpFile" in {
+    val tmp = File.createTempFile("test", "tmp")
+    val contents = createTestId()
+    FileUtils.writeStringToFile(tmp, contents, Charset.defaultCharset())
+    val downloaded = Urls.downloadToTmpFile("file://" + tmp.toString)
+    FileUtils.readFileToString(downloaded, Charset.defaultCharset()) must equal(contents)
+  }
+
+}


### PR DESCRIPTION
- In catalog, prior method of downloading was killing an actor in
    a way that was difficult to detect. Use JVM std library to download
    a URL