### PR TITLE
Change config used to specify http methods to log

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ play application config:
 By default, all HTTP methods will be logged. To only
 log a specific subset of methods, add the following:
 
-    play.http.filters.logging.methods=["GET", "PUT"]
+    play.http.logging.methods=["GET","PUT"]
 
 ## CORS
 

--- a/app/io/flow/play/util/LoggingFilter.scala
+++ b/app/io/flow/play/util/LoggingFilter.scala
@@ -25,7 +25,7 @@ class FlowLoggingFilter @javax.inject.Inject() (
   config: Config
 ) extends Filter {
 
-  private val LoggedRequestMethodConfig = "play.http.filters.logging.methods"
+  private val LoggedRequestMethodConfig = "play.http.logging.methods"
   private val DefaultLoggedRequestMethods = Seq("GET", "PATCH", "POST", "PUT", "DELETE", "OPTIONS", "HEAD")
 
   private val loggedRequestMethods = config.optionalList(LoggedRequestMethodConfig).getOrElse(DefaultLoggedRequestMethods).toSet


### PR DESCRIPTION
`play.http.filters` must be a string and adding `play.http.filters.logging.methods` makes this an object. We get the following error:
```
[info]   com.typesafe.config.ConfigException$WrongType: base.conf @ file:/home/travis/build/flowcommerce/experience/api/target/scala-2.12/classes/base.conf: 49: play.http.filters has type OBJECT rather than STRING
[info]   at com.typesafe.config.impl.SimpleConfig.findKeyOrNull(SimpleConfig.java:163)
[info]   at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:174)
[info]   at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:180)
[info]   at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:180)
[info]   at com.typesafe.config.impl.SimpleConfig.find(SimpleConfig.java:188)
[info]   at com.typesafe.config.impl.SimpleConfig.find(SimpleConfig.java:193)
[info]   at com.typesafe.config.impl.SimpleConfig.getString(SimpleConfig.java:250)
[info]   at play.api.ConfigLoader$.$anonfun$stringLoader$2(Configuration.scala:1031)
```