### PR TITLE
Add RefreshingReferenceAsync

### DIFF
--- a/app/io/flow/play/util/RefreshingReferenceAsync.scala
+++ b/app/io/flow/play/util/RefreshingReferenceAsync.scala
@@ -12,15 +12,22 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 /**
-  * Maintains a reference that gets asynchronously refreshed every `reloadInterval`.
+  * Maintains a reference that is refreshed asynchronously every `reloadInterval`.
   *
   * The data is asynchronously refreshed every `reloadInterval` period calling the `retrieve` function up to
   * `maxAtttempts` times if the function throws an exception or is completed by a failure.
-  * Upon successful completion, the cached is refreshed with the retrieved data, otherwise the cache is not refreshed
+  * Upon successful completion, the cache is refreshed with the retrieved data, otherwise the cache is not refreshed
   * and will retry `reloadInterval` after the first failed attempt.
   *
-  * The class will not initialize if the retrieval function fails the first `maxAttempts` times to avoid querying a
-  * cache that has never been initialized.
+  * The cache will throw an exception on creation if the retrieval function fails the first `maxAttempts` times to avoid
+  * querying a cache that has never been initialized.
+  *
+  * If the asynchronous `retrieve` function has not completed when the next call is scheduled, this next call is not
+  * issued.
+  *
+  * The `forceRefresh` will always issue a call to the `retrieve` function, regardless of scheduled calls or other
+  * `forceRefresh` not yet completed.
+  * Analogously to a scheduled refresh, the cache is refreshed with the retrieved data when the call completes.
   *
   * Example usage:
   *

--- a/app/io/flow/play/util/RefreshingReferenceAsync.scala
+++ b/app/io/flow/play/util/RefreshingReferenceAsync.scala
@@ -84,7 +84,7 @@ trait RefreshingReferenceAsync[T] {
 
   // load blocking and fail if the retrieval is not successful after maxAttempts
   private[this] val cache: AtomicReference[AsyncResult[T]] =
-    Try(Await.result(doLoadRetry(1, maxAttempts), 10.minutes)) match {
+    Try(Await.result(doLoadRetry(1, maxAttempts), 10.seconds)) match {
       case Success(data) =>
         new AtomicReference(data)
       case Failure(ex) =>

--- a/app/io/flow/play/util/RefreshingReferenceAsync.scala
+++ b/app/io/flow/play/util/RefreshingReferenceAsync.scala
@@ -15,10 +15,23 @@ import scala.util.{Failure, Success, Try}
   *
   * The data is asynchronously refreshed every `reloadInterval` period calling the `retrieve` function up to
   * `maxAtttempts` times if the function throws an exception or is completed by a failure.
-  * Upon successful completion, the cached is refreshed with the retrieved data, otherwise the cache is not refreshed.
+  * Upon successful completion, the cached is refreshed with the retrieved data, otherwise the cache is not refreshed
+  * and will retry `reloadInterval` after the first failed attempt.
   *
   * The class will not initialize if the retrieval function fails the first `maxAttempts` times to avoid querying a
   * cache that has never been initialized.
+  *
+  * Example usage:
+  *
+  * {{{
+  *   val cache = RefreshingReferenceAsync.fromActorSystem[Seq[Feature]](
+  *     retrieve = () => client.getAllFeatures,
+  *     system = system,
+  *     logger = logger,
+  *     reloadInterval = 2.minutes
+  *   )
+  * }}}
+  *
   */
 trait RefreshingReferenceAsync[T] {
 

--- a/app/io/flow/play/util/RefreshingReferenceAsync.scala
+++ b/app/io/flow/play/util/RefreshingReferenceAsync.scala
@@ -1,0 +1,152 @@
+package io.flow.play.util
+
+import java.time.ZonedDateTime
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.actor.Scheduler
+import io.flow.log.RollbarLogger
+
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Maintains a reference that gets refreshed every `reloadInterval`
+  *
+  * The data is refreshed every `reloadInterval` period calling the `retrieve` function up to `maxAtttempts` times
+  * Upon successful completion, the data is refreshed with the retrieved data, otherwise the cache is not refreshed.
+  *
+  * The class will not initialize if the retrieval function fails the first `maxAttempts` times to avoid querying a
+  * cache that has never been initialized.
+  */
+trait RefreshingReferenceAsync[T] {
+
+  def logger: RollbarLogger
+
+  private[this] def log: RollbarLogger = logger.withKeyValue("class", getClass.getName)
+
+  /**
+    * The scheduler to use to schedule the [[retrieve]] function every [[reloadInterval]] period.
+    */
+  def scheduler: Scheduler
+
+  /**
+    * The context to use to execute the [[retrieve]] function every [[reloadInterval]] period.
+    */
+  def retrieveExecutionContext: ExecutionContext
+
+  /**
+    * Interval between refreshes
+    */
+  def reloadInterval: FiniteDuration
+
+  /**
+    * Function retuning the data to cache.
+    * It is called every [[reloadInterval]] period.
+    * If successful, the cache is refreshed with the latest data, otherwise the cache is not refreshed.
+    */
+  def retrieve: Future[T]
+
+  /**
+    * Maximum number of attempts to retrieve the data.
+    * If the [[retrieve]] function fails [[maxAttempts]] times in a row, the cache will not refresh and will retry
+    * to retrieve data after [[reloadInterval]].
+    *
+    * Default: 3
+    */
+  def maxAttempts: Int = 3
+
+  /**
+    * Forces the cache to refresh. If successful, the cache is refreshed with the latest data, otherwise the cache is not refreshed.
+    *
+    * @return true if cache is successfully refreshed and false otherwise
+    */
+  def forceRefresh(): Future[T] = doRefresh()
+
+  def get: T = cache.get().value
+
+  // load blocking and fail if the retrieval is not successful after maxAttempts
+  private[this] val cache: AtomicReference[Result[T]] =
+    Try(Await.result(doLoadRetry(1, maxAttempts), 10.minutes)) match {
+      case Success(data) =>
+        new AtomicReference(data)
+      case Failure(ex) =>
+        log.
+          withKeyValue("max_attempts", maxAttempts).
+          warn("Failed to initialize cache", ex)
+        throw ex
+    }
+
+  // schedule subsequent reloads
+  scheduler.schedule(reloadInterval, reloadInterval)(doRefresh())(retrieveExecutionContext)
+
+  private def doRefresh(): Future[T] = {
+    val res = doLoadRetry(1, maxAttempts)
+      // update cache
+      res.onComplete {
+      case Success(data) =>
+        // only set if requested at is after
+        cache.updateAndGet { current  =>
+          if (data.requestedAt.isAfter(current.requestedAt)) data
+          else current
+        }
+      case Failure(ex) =>
+        log.
+          withKeyValue("max_attempts", maxAttempts).
+          withKeyValue("reload_interval", reloadInterval.toString).
+          warn(s"Failed to refresh cache. Will try again in $reloadInterval", ex)
+    }(retrieveExecutionContext)
+
+    res.map(_.value)(retrieveExecutionContext)
+  }
+
+
+  private def doLoadRetry(attempts: Int, maxAttempts: Int): Future[Result[T]] = {
+    val requestedAt = ZonedDateTime.now()
+    retrieve
+      .map(f => Result(requestedAt, f))(retrieveExecutionContext)
+      .recoverWith { case ex if attempts < maxAttempts =>
+      log.
+        withKeyValue("max_attempts", maxAttempts).
+        withKeyValue("reload_interval", reloadInterval.toString).
+        info(s"Failed to refresh cache ($attempts/$maxAttempts). Trying again...", ex)
+      doLoadRetry(attempts + 1, maxAttempts)
+    }(retrieveExecutionContext)
+  }
+
+}
+
+private case class Result[T](
+  requestedAt: java.time.ZonedDateTime,
+  value: T
+)
+
+object RefreshingReferenceAsync {
+
+  /**
+    * Helper function to create a new [[RefreshingReference]]
+    */
+  def apply[T](
+    rollbarLogger: RollbarLogger,
+    scheduler: Scheduler,
+    retrieveExecutionContext: ExecutionContext,
+    reloadInterval: FiniteDuration,
+    retrieve: () => Future[T],
+    maxAttempts: Int = 3
+  ): RefreshingReferenceAsync[T] = {
+    val schedulerOuter = scheduler
+    val retrieveExecutionContextOuter = retrieveExecutionContext
+    val reloadIntervalOuter = reloadInterval
+    val retrieveOuter = retrieve
+    val maxAttemptsOuter = maxAttempts
+    new RefreshingReferenceAsync[T]() {
+      override def logger: RollbarLogger = rollbarLogger
+      override def scheduler: Scheduler = schedulerOuter
+      override def retrieveExecutionContext: ExecutionContext = retrieveExecutionContextOuter
+      override def reloadInterval: FiniteDuration = reloadIntervalOuter
+      override def retrieve: Future[T] = retrieveOuter()
+      override def maxAttempts: Int = maxAttemptsOuter
+    }
+  }
+
+}

--- a/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
+++ b/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
@@ -68,7 +68,7 @@ class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite wit
 
       withCache(createCache(10.millis, retrieve)) { cache =>
         cache.get shouldBe Map("1" -> 1)
-        eventually(Timeout(30.millis), Interval(5.millis)) {
+        eventually(Timeout(50.millis), Interval(5.millis)) {
           cache.get shouldBe Map("2" -> 2)
         }
       }
@@ -82,7 +82,7 @@ class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite wit
 
       withCache(createCache(10.millis, retrieve)) { cache =>
         cache.get shouldBe Map("1" -> 1)
-        Thread.sleep(30)
+        Thread.sleep(50)
         cache.get shouldBe Map("1" -> 1)
       }
     }
@@ -95,7 +95,7 @@ class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite wit
 
       withCache(createCache(10.millis, retrieve)) { cache =>
         cache.get shouldBe Map("1" -> 1)
-        Thread.sleep(30)
+        Thread.sleep(50)
         cache.get shouldBe Map("1" -> 1)
       }
     }

--- a/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
+++ b/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
@@ -25,7 +25,7 @@ class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite wit
     retrieve: () => Future[Map[K, V]],
     maxAttempts: Int = 1
   ): RefreshingReferenceAsync[Map[K, V]] =
-    RefreshingReferenceAsync(logger, app.actorSystem.scheduler, app.actorSystem.dispatcher, reloadPeriod, retrieve, maxAttempts)
+    RefreshingReferenceAsync.fromActorSystem(retrieve, app.actorSystem, logger, reloadPeriod, maxAttempts)
 
   "RefreshingReferenceAsync" should {
 

--- a/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
+++ b/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
@@ -1,0 +1,44 @@
+package io.flow.play.util
+
+import io.flow.log.RollbarProvider
+import org.scalatest.concurrent.Eventually
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+
+import scala.concurrent.ExecutionContext.Implicits
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite with Matchers with OptionValues
+  with MockitoSugar with Eventually {
+
+  private[this] val logger = RollbarProvider.logger("test")
+
+  def createCache[K, V](
+    reloadPeriod: FiniteDuration,
+    retrieve: () => Future[Map[K, V]],
+    maxAttempts: Int = 1
+  ): RefreshingReferenceAsync[Map[K, V]] =
+    RefreshingReferenceAsync(logger, app.actorSystem.scheduler, Implicits.global, reloadPeriod, retrieve, maxAttempts)
+
+  "RefreshingReferenceAsync" should {
+
+    "load and get" in {
+      val cache = createCache[String, Int](1.minute, () => Future.successful(Map("1" -> 1)))
+      cache.get shouldBe Map("1" -> 1)
+    }
+
+    "fail to initialize if retrieve fails at startup" in {
+      val retrieve = () => throw new IllegalStateException("boom")
+      an[IllegalStateException] should be thrownBy createCache(1.minute, retrieve)
+    }
+
+    "fail to initialize if retrieved future fails at startup" in {
+      val retrieve = () => Future.failed(new IllegalStateException("boom"))
+      an[IllegalStateException] should be thrownBy createCache(1.minute, retrieve)
+    }
+
+  }
+
+}

--- a/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
+++ b/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
@@ -2,16 +2,16 @@ package io.flow.play.util
 
 import io.flow.log.RollbarProvider
 import org.mockito.Mockito
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{EitherValues, Matchers, OptionValues, WordSpec}
+import org.scalatest._
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.concurrent.Futures
+import play.api.libs.concurrent.Futures._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import play.api.libs.concurrent.Futures._
 
 class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite with Matchers with OptionValues
   with MockitoSugar with Eventually with ScalaFutures with EitherValues {
@@ -20,113 +20,130 @@ class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite wit
   implicit private[this] val system = app.actorSystem
   private[this] val futures = implicitly[Futures]
 
-  def createCache[K, V](
+  private def createCache[K, V](
     reloadPeriod: FiniteDuration,
     retrieve: () => Future[Map[K, V]],
     maxAttempts: Int = 1
   ): RefreshingReferenceAsync[Map[K, V]] =
     RefreshingReferenceAsync.fromActorSystem(retrieve, app.actorSystem, logger, reloadPeriod, maxAttempts)
 
+  private def withCache[K,V](
+    cache: RefreshingReferenceAsync[Map[K, V]]
+  )(
+    f: RefreshingReferenceAsync[Map[K, V]] => Assertion
+  ): Assertion =
+    try {
+      f(cache)
+    } finally {
+      cache.shutdown()
+      ()
+    }
+
+  private def withCacheInit[K,V](cache: RefreshingReferenceAsync[Map[K, V]]): Assertion =
+    withCache(cache)(_ => Succeeded)
+
   "RefreshingReferenceAsync" should {
 
     "load and get" in {
-      val cache = createCache[String, Int](1.minute, () => Future.successful(Map("1" -> 1)))
+      withCache(createCache[String, Int](1.minute, () => Future.successful(Map("1" -> 1)))) { cache =>
       cache.get shouldBe Map("1" -> 1)
+      }
     }
 
     "fail to initialize if retrieve fails at startup" in {
       val retrieve = () => throw new IllegalStateException("boom")
-      an[IllegalStateException] should be thrownBy createCache(1.minute, retrieve)
+      an[IllegalStateException] should be thrownBy withCacheInit(createCache(1.minute, retrieve))
     }
 
     "fail to initialize if retrieved future fails at startup" in {
       val retrieve = () => Future.failed(new IllegalStateException("boom"))
-      an[IllegalStateException] should be thrownBy createCache(1.minute, retrieve)
+      an[IllegalStateException] should be thrownBy withCacheInit(createCache(1.minute, retrieve))
     }
 
     "refresh data" in {
       val retrieve = mock[() => Future[Map[String, Int]]]
       Mockito.when(retrieve.apply())
-        .thenReturn(Future.successful(Map("1" -> 1)))
-        .thenReturn(futures.delayed(20.millis)(Future.successful(Map("2" -> 2))))
+        .thenAnswer(_ => Future.successful(Map("1" -> 1)))
+        .thenAnswer(_ => Future.successful(Map("2" -> 2)))
 
-      val cache = createCache(10.millis, retrieve)
-
-      cache.get shouldBe Map("1" -> 1)
-      eventually(Timeout(50.millis)) {
-        cache.get shouldBe Map("2" -> 2)
+      withCache(createCache(10.millis, retrieve)) { cache =>
+        cache.get shouldBe Map("1" -> 1)
+        eventually(Timeout(30.millis), Interval(5.millis)) {
+          cache.get shouldBe Map("2" -> 2)
+        }
       }
     }
 
     "return old data if retrieve fails" in {
       val retrieve = mock[() => Future[Map[String, Int]]]
       Mockito.when(retrieve.apply())
-        .thenReturn(Future.successful(Map("1" -> 1)))
-        .thenReturn(futures.delayed(20.millis)(Future.failed(new IllegalStateException("boom"))))
+        .thenAnswer(_ => Future.successful(Map("1" -> 1)))
+        .thenAnswer(_ => Future.failed(new IllegalStateException("boom")))
 
-      val cache = createCache(10.millis, retrieve)
-
-      cache.get shouldBe Map("1" -> 1)
-      Thread.sleep(50)
-      cache.get shouldBe Map("1" -> 1)
+      withCache(createCache(10.millis, retrieve)) { cache =>
+        cache.get shouldBe Map("1" -> 1)
+        Thread.sleep(30)
+        cache.get shouldBe Map("1" -> 1)
+      }
     }
 
     "return old data if retrieve throws an exception" in {
       val retrieve = mock[() => Future[Map[String, Int]]]
       Mockito.when(retrieve.apply())
-        .thenReturn(Future.successful(Map("1" -> 1)))
-        .thenThrow(new IllegalStateException("boom"))
+        .thenAnswer(_ => Future.successful(Map("1" -> 1)))
+        .thenAnswer(_ => new IllegalStateException("boom"))
 
-      val cache = createCache(10.millis, retrieve)
-
-      cache.get shouldBe Map("1" -> 1)
-      Thread.sleep(50)
-      cache.get shouldBe Map("1" -> 1)
+      withCache(createCache(10.millis, retrieve)) { cache =>
+        cache.get shouldBe Map("1" -> 1)
+        Thread.sleep(30)
+        cache.get shouldBe Map("1" -> 1)
+      }
     }
 
     "keep retrying if retrieve fails" in {
       val retrieve = mock[() => Future[Map[String, Int]]]
       Mockito.when(retrieve.apply())
-        .thenReturn(Future.successful(Map("1" -> 1, "2" -> 2)))
-        .thenReturn(futures.delayed(10.millis)(Future.failed(new IllegalStateException("boom"))))
-        .thenReturn(futures.delayed(20.millis)(Future.successful(Map("3" -> 3, "4" -> 4))))
+        .thenAnswer(_ => Future.successful(Map("1" -> 1, "2" -> 2)))
+        .thenAnswer(_ => Future.failed(new IllegalStateException("boom")))
+        .thenAnswer(_ => Future.successful(Map("3" -> 3, "4" -> 4)))
 
-      val cache = createCache(10.millis, retrieve)
-
-      cache.get shouldBe Map("1" -> 1, "2" -> 2)
-      eventually(Timeout(50.millis)) {
-        cache.get shouldBe Map("3" -> 3, "4" -> 4)
+      withCache(createCache(10.millis, retrieve)) { cache =>
+        cache.get shouldBe Map("1" -> 1, "2" -> 2)
+        eventually(Timeout(50.millis), Interval(5.millis)) {
+          cache.get shouldBe Map("3" -> 3, "4" -> 4)
+        }
       }
     }
 
     "keep retrying if retrieve thows an exception" in {
       val retrieve = mock[() => Future[Map[String, Int]]]
       Mockito.when(retrieve.apply())
-        .thenReturn(Future.successful(Map("1" -> 1, "2" -> 2)))
-        .thenThrow(new IllegalStateException("boom"))
-        .thenReturn(futures.delayed(20.millis)(Future.successful(Map("3" -> 3, "4" -> 4))))
+        .thenAnswer(_ => Future.successful(Map("1" -> 1, "2" -> 2)))
+        .thenAnswer(_ => new IllegalStateException("boom"))
+        .thenAnswer(_ => Future.successful(Map("3" -> 3, "4" -> 4)))
 
-      val cache = createCache(10.millis, retrieve)
+      withCache(createCache(10.millis, retrieve)) { cache =>
 
-      cache.get shouldBe Map("1" -> 1, "2" -> 2)
-      eventually(Timeout(50.millis)) {
-        cache.get shouldBe Map("3" -> 3, "4" -> 4)
+        cache.get shouldBe Map("1" -> 1, "2" -> 2)
+        eventually(Timeout(50.millis), Interval(5.millis)) {
+          cache.get shouldBe Map("3" -> 3, "4" -> 4)
+        }
       }
     }
 
     "retry to retrieve when retrieve fails or throws an exception" in {
       val retrieve = mock[() => Future[Map[String, Int]]]
       Mockito.when(retrieve.apply())
-        .thenReturn(Future.successful(Map("1" -> 1, "2" -> 2)))
-        .thenThrow(new IllegalStateException("boom"))
-        .thenReturn(futures.delayed(10.millis)(Future.failed(new IllegalStateException("boom"))))
-        .thenReturn(futures.delayed(20.millis)(Future.successful(Map("3" -> 3, "4" -> 4))))
+        .thenAnswer(_ => Future.successful(Map("1" -> 1, "2" -> 2)))
+        .thenAnswer(_ => new IllegalStateException("boom"))
+        .thenAnswer(_ => Future.failed(new IllegalStateException("boom")))
+        .thenAnswer(_ => Future.successful(Map("3" -> 3, "4" -> 4)))
 
-      val cache = createCache(30.millis, retrieve, maxAttempts = 3)
-
-      cache.get shouldBe Map("1" -> 1, "2" -> 2)
-      eventually(Timeout(50.millis)) {
-        cache.get shouldBe Map("3" -> 3, "4" -> 4)
+      withCache(createCache(10.millis, retrieve, maxAttempts = 3)) { cache =>
+        cache.get shouldBe Map("1" -> 1, "2" -> 2)
+        eventually(Timeout(50.millis), Interval(5.millis)) {
+          cache.get shouldBe Map("3" -> 3, "4" -> 4)
+        }
       }
     }
 
@@ -136,30 +153,61 @@ class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite wit
         .thenReturn(Future.successful(Map("1" -> 1)))
         .thenReturn(Future.successful(Map("2" -> 2)))
 
-      val cache = createCache(1.day, retrieve)
-      cache.get shouldBe Map("1" -> 1)
-      val f = cache.forceRefresh()
+      withCache(createCache(1.day, retrieve)) { cache =>
+        cache.get shouldBe Map("1" -> 1)
+        val f = cache.forceRefresh()
 
-      eventually(Timeout(100.millis)) {
-        cache.get shouldBe Map("2" -> 2)
+        eventually(Timeout(50.millis), Interval(5.millis)) {
+          cache.get shouldBe Map("2" -> 2)
+        }
+        // f must be completed
+        f.eitherValue.value.right.value shouldBe Map("2" -> 2)
       }
-      // f must be completed
-      f.eitherValue.value.right.value shouldBe Map("2" -> 2)
     }
 
     "fetch at most once at a time" in {
       val retrieve = mock[() => Future[Map[String, Int]]]
       Mockito.when(retrieve.apply())
-        .thenReturn(Future.successful(Map("1" -> 1)))
-        .thenReturn(futures.delayed(50.millis)(Future.successful(Map("2" -> 2))))
+        .thenAnswer(_ => Future.successful(Map("1" -> 1)))
+        .thenAnswer(_ => futures.delayed(50.millis)(Future.successful(Map("2" -> 2))))
 
-      val cache = createCache(10.millis, retrieve)
-
-      eventually(Timeout(100.millis)) {
-        cache.get shouldBe Map("2" -> 2)
-        Mockito.verify(retrieve, Mockito.times(2)).apply()
+      withCache(createCache(10.millis, retrieve)) { cache =>
+        eventually(Timeout(120.millis), Interval(5.millis)) {
+          cache.get shouldBe Map("2" -> 2)
+          // 1: init
+          // 2: first fetch (~50 ms)
+          // 3: not completed retrieve
+          Mockito.verify(retrieve, Mockito.times(3)).apply()
+        }
+        Succeeded
       }
+    }
 
+    "force the cache to refresh while retrieve in flight" in {
+      val retrieve = mock[() => Future[Map[String, Int]]]
+      Mockito.when(retrieve.apply())
+        .thenAnswer(_ => Future.successful(Map("1" -> 1)))
+        .thenAnswer(_ => futures.delayed(70.millis)(Future.successful(Map("2" -> 2))))
+
+      withCache(createCache(10.millis, retrieve)) { cache =>
+        eventually(Timeout(30.millis), Interval(5.millis)) {
+          cache.get shouldBe Map("1" -> 1)
+          // 1: init
+          // 2: first fetch (~50 ms)
+          Mockito.verify(retrieve, Mockito.times(2)).apply()
+        }
+
+        cache.forceRefresh()
+
+        eventually(Timeout(100.millis), Interval(5.millis)) {
+          cache.get shouldBe Map("1" -> 1)
+          // 1: init
+          // 2: first fetch (~50 ms)
+          // 3: force refresh
+          Mockito.verify(retrieve, Mockito.times(3)).apply()
+        }
+        Succeeded
+      }
     }
 
   }

--- a/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
+++ b/test/io/flow/play/util/RefreshingReferenceAsyncSpec.scala
@@ -1,26 +1,31 @@
 package io.flow.play.util
 
 import io.flow.log.RollbarProvider
-import org.scalatest.concurrent.Eventually
+import org.mockito.Mockito
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatest.{EitherValues, Matchers, OptionValues, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.libs.concurrent.Futures
 
-import scala.concurrent.ExecutionContext.Implicits
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import play.api.libs.concurrent.Futures._
 
 class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite with Matchers with OptionValues
-  with MockitoSugar with Eventually {
+  with MockitoSugar with Eventually with ScalaFutures with EitherValues {
 
   private[this] val logger = RollbarProvider.logger("test")
+  implicit private[this] val system = app.actorSystem
+  private[this] val futures = implicitly[Futures]
 
   def createCache[K, V](
     reloadPeriod: FiniteDuration,
     retrieve: () => Future[Map[K, V]],
     maxAttempts: Int = 1
   ): RefreshingReferenceAsync[Map[K, V]] =
-    RefreshingReferenceAsync(logger, app.actorSystem.scheduler, Implicits.global, reloadPeriod, retrieve, maxAttempts)
+    RefreshingReferenceAsync(logger, app.actorSystem.scheduler, app.actorSystem.dispatcher, reloadPeriod, retrieve, maxAttempts)
 
   "RefreshingReferenceAsync" should {
 
@@ -37,6 +42,109 @@ class RefreshingReferenceAsyncSpec extends WordSpec with GuiceOneAppPerSuite wit
     "fail to initialize if retrieved future fails at startup" in {
       val retrieve = () => Future.failed(new IllegalStateException("boom"))
       an[IllegalStateException] should be thrownBy createCache(1.minute, retrieve)
+    }
+
+    "refresh data" in {
+      val retrieve = mock[() => Future[Map[String, Int]]]
+      Mockito.when(retrieve.apply())
+        .thenReturn(Future.successful(Map("1" -> 1)))
+        .thenReturn(futures.delayed(20.millis)(Future.successful(Map("2" -> 2))))
+
+      val cache = createCache(10.millis, retrieve)
+
+      cache.get shouldBe Map("1" -> 1)
+      eventually(Timeout(50.millis)) {
+        cache.get shouldBe Map("2" -> 2)
+      }
+    }
+
+    "return old data if retrieve fails" in {
+      val retrieve = mock[() => Future[Map[String, Int]]]
+      Mockito.when(retrieve.apply())
+        .thenReturn(Future.successful(Map("1" -> 1)))
+        .thenReturn(futures.delayed(20.millis)(Future.failed(new IllegalStateException("boom"))))
+
+      val cache = createCache(10.millis, retrieve)
+
+      cache.get shouldBe Map("1" -> 1)
+      Thread.sleep(50)
+      cache.get shouldBe Map("1" -> 1)
+    }
+
+    "return old data if retrieve throws an exception" in {
+      val retrieve = mock[() => Future[Map[String, Int]]]
+      Mockito.when(retrieve.apply())
+        .thenReturn(Future.successful(Map("1" -> 1)))
+        .thenThrow(new IllegalStateException("boom"))
+
+      val cache = createCache(10.millis, retrieve)
+
+      cache.get shouldBe Map("1" -> 1)
+      Thread.sleep(50)
+      cache.get shouldBe Map("1" -> 1)
+    }
+
+    "keep retrying if retrieve fails" in {
+      val retrieve = mock[() => Future[Map[String, Int]]]
+      Mockito.when(retrieve.apply())
+        .thenReturn(Future.successful(Map("1" -> 1, "2" -> 2)))
+        .thenReturn(futures.delayed(10.millis)(Future.failed(new IllegalStateException("boom"))))
+        .thenReturn(futures.delayed(20.millis)(Future.successful(Map("3" -> 3, "4" -> 4))))
+
+      val cache = createCache(10.millis, retrieve)
+
+      cache.get shouldBe Map("1" -> 1, "2" -> 2)
+      eventually(Timeout(50.millis)) {
+        cache.get shouldBe Map("3" -> 3, "4" -> 4)
+      }
+    }
+
+    "keep retrying if retrieve thows an exception" in {
+      val retrieve = mock[() => Future[Map[String, Int]]]
+      Mockito.when(retrieve.apply())
+        .thenReturn(Future.successful(Map("1" -> 1, "2" -> 2)))
+        .thenThrow(new IllegalStateException("boom"))
+        .thenReturn(futures.delayed(20.millis)(Future.successful(Map("3" -> 3, "4" -> 4))))
+
+      val cache = createCache(10.millis, retrieve)
+
+      cache.get shouldBe Map("1" -> 1, "2" -> 2)
+      eventually(Timeout(50.millis)) {
+        cache.get shouldBe Map("3" -> 3, "4" -> 4)
+      }
+    }
+
+    "retry to retrieve when retrieve fails or throws an exception" in {
+      val retrieve = mock[() => Future[Map[String, Int]]]
+      Mockito.when(retrieve.apply())
+        .thenReturn(Future.successful(Map("1" -> 1, "2" -> 2)))
+        .thenThrow(new IllegalStateException("boom"))
+        .thenReturn(futures.delayed(10.millis)(Future.failed(new IllegalStateException("boom"))))
+        .thenReturn(futures.delayed(20.millis)(Future.successful(Map("3" -> 3, "4" -> 4))))
+
+      val cache = createCache(30.millis, retrieve, maxAttempts = 3)
+
+      cache.get shouldBe Map("1" -> 1, "2" -> 2)
+      eventually(Timeout(50.millis)) {
+        cache.get shouldBe Map("3" -> 3, "4" -> 4)
+      }
+    }
+
+    "force the cache to refresh" in {
+      val retrieve = mock[() => Future[Map[String, Int]]]
+      Mockito.when(retrieve.apply())
+        .thenReturn(Future.successful(Map("1" -> 1)))
+        .thenReturn(Future.successful(Map("2" -> 2)))
+
+      val cache = createCache(1.day, retrieve)
+      cache.get shouldBe Map("1" -> 1)
+      val f = cache.forceRefresh()
+
+      eventually(Timeout(100.millis)) {
+        cache.get shouldBe Map("2" -> 2)
+      }
+      // f must be completed
+      f.eitherValue.value.right.value shouldBe Map("2" -> 2)
     }
 
   }


### PR DESCRIPTION
Introduces a new `RefreshingReferenceAsync` that self refreshes asynchronously.

```
Maintains a reference that is refreshed asynchronously every `reloadInterval`.

The data is asynchronously refreshed every `reloadInterval` period calling the
`retrieve` function up to `maxAtttempts` times if the function throws an exception
or is completed by a failure.
Upon successful completion, the cache is refreshed with the retrieved data,
otherwise the cache is not refreshe dand will retry `reloadInterval` after the first
failed attempt.

The cache will throw an exception on creation if the retrieval function fails the
first `maxAttempts` times to avoid querying a cache that has never been initialized.

If the asynchronous `retrieve` function has not completed when the next call is
scheduled, this next call is not issued.

The `forceRefresh` will always issue a call to the `retrieve` function, regardless
of scheduled calls or other `forceRefresh` not yet completed.
Analogously to a scheduled refresh, the cache is refreshed with the retrieved data
when the call completes.
```

Example usage:
```scala
val cache = RefreshingReferenceAsync.fromActorSystem[Seq[Feature]](
  retrieve = () => client.getAllFeatures,
  system = system,
  logger = logger,
  reloadInterval = 2.minutes
)
```

The advantage of the following approach is to offer an interface:

```scala
def get: T
```

that self refreshes **asynchronously and without blocking**.