### PR TITLE
Better play

### DIFF
--- a/app/io/flow/play/bodyparsers/JsonReadsBodyParsers.scala
+++ b/app/io/flow/play/bodyparsers/JsonReadsBodyParsers.scala
@@ -1,0 +1,28 @@
+package io.flow.play.bodyparsers
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.{BodyParser, PlayBodyParsers, Results}
+import play.api.libs.json._
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class JsonReadsBodyParsers @Inject()(bodyParsers: PlayBodyParsers,
+                                     results: Results) {
+
+  def tolerantJsonReads[A: Reads](
+      implicit ec: ExecutionContext): BodyParser[A] =
+    jsonReads(bodyParsers.tolerantJson)
+
+  def jsonReads[A: Reads](implicit ec: ExecutionContext): BodyParser[A] =
+    jsonReads(bodyParsers.json)
+
+  def jsonReads[A: Reads](bodyParser: BodyParser[JsValue])(
+      implicit ec: ExecutionContext): BodyParser[A] =
+    bodyParser.validate { jsValue =>
+      jsValue
+        .validate[A]
+        .asEither
+        .left.map(e => results.BadRequest(JsError.toJson(e)))
+    }
+
+}

--- a/app/io/flow/play/util/Result.scala
+++ b/app/io/flow/play/util/Result.scala
@@ -1,0 +1,32 @@
+package io.flow.play.util
+
+import play.api.mvc.{Result => PlayResult}
+import scala.concurrent.{ExecutionContext, Future}
+
+trait Result[A] {
+  def toPlayResult(value: A): Future[PlayResult]
+}
+
+object Result {
+  def apply[A: Result] = implicitly[Result[A]]
+  implicit class ResultOps[A: Result](a: A) {
+    def toPlayResult = Result[A].toPlayResult(a)
+  }
+
+  implicit def toPlayResult[A: Result](value: A): Future[PlayResult] =
+    value.toPlayResult
+
+  implicit val resultToR = new Result[PlayResult] {
+    def toPlayResult(value: PlayResult) = Future.successful(value)
+  }
+
+  implicit def futureRToR[A: Result](implicit ec: ExecutionContext) =
+    new Result[Future[A]] {
+      def toPlayResult(value: Future[A]) = value.flatMap(_.toPlayResult)
+    }
+
+  implicit def eitherRToR[A: Result, B: Result] = new Result[Either[A, B]] {
+    def toPlayResult(value: Either[A, B]) =
+      value.fold(_.toPlayResult, _.toPlayResult)
+  }
+}

--- a/app/io/flow/play/util/Result.scala
+++ b/app/io/flow/play/util/Result.scala
@@ -3,8 +3,10 @@ package io.flow.play.util
 import play.api.mvc.{Result => PlayResult}
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Result[A] {
-  def toPlayResult(value: A): Future[PlayResult]
+trait Result[A] extends AsyncResult[A] {
+  def toPlayResult(value: A): PlayResult
+  def toPlayAsyncResult(value: A): Future[PlayResult] =
+    Future.successful(toPlayResult(value))
 }
 
 object Result {
@@ -13,20 +15,43 @@ object Result {
     def toPlayResult = Result[A].toPlayResult(a)
   }
 
-  implicit def toPlayResult[A: Result](value: A): Future[PlayResult] =
+  implicit def toPlayResult[A: Result](value: A): PlayResult =
     value.toPlayResult
 
   implicit val resultToR = new Result[PlayResult] {
-    def toPlayResult(value: PlayResult) = Future.successful(value)
+    def toPlayResult(value: PlayResult): PlayResult = value
   }
-
-  implicit def futureRToR[A: Result](implicit ec: ExecutionContext) =
-    new Result[Future[A]] {
-      def toPlayResult(value: Future[A]) = value.flatMap(_.toPlayResult)
-    }
 
   implicit def eitherRToR[A: Result, B: Result] = new Result[Either[A, B]] {
-    def toPlayResult(value: Either[A, B]) =
-      value.fold(_.toPlayResult, _.toPlayResult)
+    def toPlayResult(value: Either[A, B]): PlayResult =
+      value.fold(Result[A].toPlayResult, Result[B].toPlayResult)
   }
+}
+
+trait AsyncResult[A] {
+  def toPlayAsyncResult(value: A): Future[PlayResult]
+}
+
+object AsyncResult {
+  def apply[A: AsyncResult] = implicitly[AsyncResult[A]]
+  implicit class ResultOps[A: AsyncResult](a: A) {
+    def toPlayAsyncResult = AsyncResult[A].toPlayAsyncResult(a)
+  }
+
+  implicit def toPlayAsyncResult[A: AsyncResult](value: A): Future[PlayResult] =
+    value.toPlayAsyncResult
+
+  implicit def eitherRToAR[A: AsyncResult, B: AsyncResult] =
+    new AsyncResult[Either[A, B]] {
+      def toPlayAsyncResult(value: Either[A, B]): Future[PlayResult] =
+        value.fold(AsyncResult[A].toPlayAsyncResult,
+                   AsyncResult[B].toPlayAsyncResult)
+    }
+
+  implicit def futureRToAR[A: AsyncResult](implicit ec: ExecutionContext) =
+    new AsyncResult[Future[A]] {
+      def toPlayAsyncResult(value: Future[A]): Future[PlayResult] =
+        value.flatMap(AsyncResult[A].toPlayAsyncResult)
+    }
+
 }

--- a/app/io/flow/play/writeables/JsonThrowableWriteable.scala
+++ b/app/io/flow/play/writeables/JsonThrowableWriteable.scala
@@ -1,0 +1,18 @@
+package io.flow.play.writeables
+
+import javax.inject.{Inject, Singleton}
+import play.api.http.{DefaultWriteables, Writeable}
+import play.api.libs.json.Json
+
+@Singleton
+class JsonThrowableWriteable @Inject()(writeables: DefaultWriteables) {
+
+  implicit val writeableOf_JsonThrowable: Writeable[Throwable] =
+    writeables.writeableOf_JsValue.map[Throwable] { throwable =>
+      val message = Option(throwable.getMessage).getOrElse("""¯\_(ツ)_/¯""")
+      Json.obj("status" -> "KO", "message" -> message)
+    }
+
+}
+
+object JsonThrowableWriteable extends JsonThrowableWriteable(Writeable)

--- a/app/io/flow/play/writeables/JsonWritesWriteable.scala
+++ b/app/io/flow/play/writeables/JsonWritesWriteable.scala
@@ -1,0 +1,15 @@
+package io.flow.play.writeables
+
+import javax.inject.{Inject, Singleton}
+import play.api.http.{DefaultWriteables, Writeable}
+import play.api.libs.json.{Json, Writes}
+
+@Singleton
+class JsonWritesWriteable @Inject()(writeables: DefaultWriteables) {
+
+  implicit def writeableOf_JsonWrites[A: Writes]: Writeable[A] =
+    writeables.writeableOf_JsValue.map[A](Json.toJson)
+
+}
+
+object JsonWritesWriteable extends JsonThrowableWriteable(Writeable)


### PR DESCRIPTION
Our play actions contain a lot of boilerplate. This PR tries to limit the amount by using sensible defaults.

### Writeable
Play `Result` are created from a `Status`, and a `Writeable` object. This requires us to convert objects to given types for Play to be happy.

```scala
Ok(Json.toJson(myObject))
```

This makes a lot of sense in a world with XML, and the sorts, but when JSON is king, this is just annoying. To avoid explicitly requesting JSON conversions, if a `json.Writes` is available, the object will be converted automatically.

```scala
import io.flow.play.writeables.JsonWritesWriteable._ // Or inject the class 
import io.flow.my.service.v0.models.json._

Ok(Json.toJson(myObject))
```

A writer also exists for `Throwable`.

### BodyParser
Play can parse payloads. This is often done with `parse.json`. The request becomes `Request[JsValue]`, and that needs to be parsed again ...

```scala
Action(parse.json) { req =>
  val body = req.body.as[MyType]
  ???
}
```

Similarly to the previous point, there is little value to rewrite the opening over, and over again. Two new body parsers allow to convert the body automatically given `json.Reads`.

```scala
import io.flow.play.bodyparsers.JsonReadsBodyParsers // needs to be injected

class MyController @Inject()(jsonBodyParsers: JsonReadsBodyParsers, ...) {
  def myAction = Action(jsonBodyParsers.jsonReads[MyType]) { req =>
    val body = req.body
  }
}
```

### Result
The controversial part of this PR ... type classes. Actions don't always succeed. This often requires a lot of brackets to return the proper `Result`. 

```scala
def myAction(limit: Int) = Action { req =>
  if(id < 0) UnprocessableEntity("Limit too small") 
  else if (id > 1000) UnprocessableEntity("Limit too big") 
  else {
    ???
    OK("")
  }
}
```

This makes the code a bit hard to follow when an `Either` could help.
```scala
def myAction(limit: Int) = Action { req =>
  val f = for {
    _ <- Either.cond(id < 0, (), UnprocessableEntity("Limit too small"))
    _ <- Either.cond(id > 0, (), UnprocessableEntity("Limit too big"))
    ???
  } yield Ok("")

  f.merge
}
```

`Result`, `Future[Result]`, and `Either[Result, Result]` could easily all be valid return types, but Play doesn't understand that. The `Result` type class allows an automatic conversion of some type of `Result`, currently only the 3 aboves, to avoid `.merge`, `Future.successful`, and the sorts.

```scala
import io.flow.play.util.Result._

def myAction1 = Action.async { req =>
    if (1 == 1) Ok(Healthcheck(status = "healthy")) // play.api.mvc.Result
    else Future.successful(BadRequest("")) // Future[play.api.mvc.Result]
}

def myAction2 = Action.async { req =>
  for {
    _ <- Either.cond(id < 0, (), UnprocessableEntity("Limit too small"))
    _ <- Either.cond(id > 0, (), UnprocessableEntity("Limit too big"))
    ???
  } yield Ok("")
}
```

Hopefully those 3 points will help hide boilerplate, and surface issues within our code.