### PR TITLE
[Returning Customers] Cleanup unnecessary AuthData

### DIFF
--- a/app/io/flow/play/util/AuthData.scala
+++ b/app/io/flow/play/util/AuthData.scala
@@ -287,42 +287,7 @@ object AuthData {
     }
 
   }
-
-  case class Customer(
-    override val createdAt: DateTime = DateTime.now,
-    override val requestId: String,
-    session: FlowSession,
-    customer: CustomerReference
-  ) extends AuthData {
-
-    override protected def decorate(base: AuthDataMap): AuthDataMap = {
-      base.copy(
-        session = Some(session),
-        customer = Some(customer)
-      )
-    }
-
-  }
-
-  object Customer {
-
-    def fromMap(data: Map[String, String])(implicit logger: RollbarLogger): Option[Customer] = {
-      AuthDataMap.fromMap(data) { dm =>
-        (dm.session, dm.customer) match {
-          case (Some(session), Some(customer)) =>
-            Some(Customer(
-              createdAt = dm.createdAt,
-              requestId = dm.requestId,
-              session = session,
-              customer = customer
-            ))
-
-          case _ => None
-        }
-      }
-    }
-
-  }
+  
 }
 
 object OrgAuthData {

--- a/app/io/flow/play/util/AuthHeaders.scala
+++ b/app/io/flow/play/util/AuthHeaders.scala
@@ -62,11 +62,15 @@ object AuthHeaders {
 
   def customer(
     requestId: String = generateRequestId(),
+    org: String,
+    environment: Environment = Environment.Sandbox,
     session: FlowSession = createFlowSession(),
     customer: CustomerReference = createCustomerReference()
-  ): AuthData.Customer = {
-    AuthData.Customer(
+  ): OrgAuthData.Customer = {
+    OrgAuthData.Customer(
       requestId = requestId,
+      organization = org,
+      environment = environment,
       session = session,
       customer = customer
     )


### PR DESCRIPTION
`AuthData` not required, remove it.

Implementation will only require `OrgAuthData`.