### PR TITLE
[Returning Customers] Wrapper to auth customer org  or session

### DIFF
--- a/app/io/flow/play/util/AuthData.scala
+++ b/app/io/flow/play/util/AuthData.scala
@@ -467,4 +467,23 @@ object OrgAuthData {
     }
   }
 
+
+  /**
+    * Required wrapper to assist in migrating authorization in Checkout UI.
+    * Authorization header may be passed as either a Bearer JWT (represented as a OrgAuthData.Customer)
+    * or the legacy session (represented as an AuthData.Session)
+    *
+    * Note the different, intentionally referenced traits, OrgAuthData vs. AuthData
+    */
+  object Checkout {
+
+    /**
+      * Parses either a customer org or a session (or None)
+      */
+    def fromMap(data: Map[String, String])(implicit logger: RollbarLogger): Option[io.flow.play.util.AuthData] = {
+      OrgAuthData.Customer.fromMap(data)
+        .orElse(AuthData.Session.fromMap(data))
+    }
+  }
+
 }

--- a/test/io/flow/play/util/AuthDataSpec.scala
+++ b/test/io/flow/play/util/AuthDataSpec.scala
@@ -1,8 +1,12 @@
 package io.flow.play.util
 
 import io.flow.common.v0.models.{Environment, Role, UserReference}
+import io.flow.log.RollbarProvider
+import io.flow.play.util.AuthDataMap.Fields
 
 class AuthDataSpec extends LibPlaySpec {
+
+  private[this] val logger = RollbarProvider.logger("test")
 
   "AuthData.user" in {
     val id = "user-1"
@@ -32,6 +36,39 @@ class AuthDataSpec extends LibPlaySpec {
 
     val all = 1.to(100).map { _ => AuthHeaders.generateRequestId("foo") }
     all.distinct.size must be(100)
+  }
+
+  "OrgAuthData.Checkout - customer" in {
+    val orgAuthDataCustomer = AuthHeaders.organizationCustomer(org = createTestId())
+    val customerData: Map[String, String] = Map(
+      Fields.CreatedAt -> orgAuthDataCustomer.createdAt.toString,
+      Fields.RequestId -> orgAuthDataCustomer.requestId,
+      Fields.Organization -> orgAuthDataCustomer.organization,
+      Fields.Environment -> orgAuthDataCustomer.environment.toString,
+      Fields.Session -> orgAuthDataCustomer.session.id,
+      Fields.Customer -> orgAuthDataCustomer.customer.number
+    )
+
+    val auth: Option[AuthData] = OrgAuthData.Checkout.fromMap(customerData)(logger)
+
+    auth.get.isInstanceOf[OrgAuthData.Customer] must be(true)
+    val customer = auth.get.asInstanceOf[OrgAuthData.Customer]
+    customer must be(orgAuthDataCustomer)
+  }
+
+  "OrgAuthData.Checkout - session" in {
+    val authDataSession = AuthHeaders.session()
+    val sessionData: Map[String, String] = Map(
+      Fields.CreatedAt -> authDataSession.createdAt.toString,
+      Fields.RequestId -> authDataSession.requestId,
+      Fields.Session -> authDataSession.session.id,
+    )
+
+    val auth: Option[AuthData] = OrgAuthData.Checkout.fromMap(sessionData)(logger)
+
+    auth.get.isInstanceOf[AuthData.Session] must be(true)
+    val session = auth.get.asInstanceOf[AuthData.Session]
+    session must be(authDataSession)
   }
 
 }


### PR DESCRIPTION
Auth data used to authorize calls to checkout/bundle that must support legacy `session <session id>` and `bearer <jwt>`