### PR TITLE
[Returning Customers] IdentifiedCustomer wrapper

### DIFF
--- a/app/io/flow/play/controllers/FlowController.scala
+++ b/app/io/flow/play/controllers/FlowController.scala
@@ -33,6 +33,7 @@ trait FlowController extends BaseController with FlowControllerHelpers {
   def CustomerOrg: CustomerOrgActionBuilder = flowControllerComponents.customerOrgActionBuilder
   def Checkout: CheckoutActionBuilder = flowControllerComponents.checkoutActionBuilder
   def CheckoutOrg: CheckoutOrgActionBuilder = flowControllerComponents.checkoutOrgActionBuilder
+  def IdentifiedCustomer: IdentifiedCustomerActionBuilder = flowControllerComponents.identifiedCustomerActionBuilder
 }
 
 @ImplementedBy(classOf[FlowDefaultControllerComponents])
@@ -48,6 +49,7 @@ trait FlowControllerComponents {
   def customerOrgActionBuilder: CustomerOrgActionBuilder
   def checkoutActionBuilder: CheckoutActionBuilder
   def checkoutOrgActionBuilder: CheckoutOrgActionBuilder
+  def identifiedCustomerActionBuilder: IdentifiedCustomerActionBuilder
 }
 
 case class FlowDefaultControllerComponents @Inject()(
@@ -61,7 +63,8 @@ case class FlowDefaultControllerComponents @Inject()(
   identifiedCookieActionBuilder: IdentifiedCookieActionBuilder,
   customerOrgActionBuilder: CustomerOrgActionBuilder,
   checkoutActionBuilder: CheckoutActionBuilder,
-  checkoutOrgActionBuilder: CheckoutOrgActionBuilder
+  checkoutOrgActionBuilder: CheckoutOrgActionBuilder,
+  identifiedCustomerActionBuilder: IdentifiedCustomerActionBuilder
 ) extends FlowControllerComponents
 
 // Anonymous
@@ -198,5 +201,18 @@ class CustomerOrgActionBuilder @Inject()(val parser: BodyParsers.Default, val co
     auth(request.headers)(OrgAuthData.Customer.fromMap) match {
       case None => Future.successful(unauthorized(request))
       case Some(ad) => block(new CustomerOrgRequest(ad, request))
+    }
+}
+
+// IdentifiedCustomer
+class IdentifiedCustomerActionBuilder @Inject()(val parser: BodyParsers.Default, val config: Config)(
+  implicit private val logger: RollbarLogger,
+  implicit val executionContext: ExecutionContext
+) extends ActionBuilder[IdentifiedCustomerRequest, AnyContent] with FlowActionInvokeBlockHelper {
+
+  def invokeBlock[A](request: Request[A], block: IdentifiedCustomerRequest[A] => Future[Result]): Future[Result] =
+    auth(request.headers)(OrgAuthData.IdentifiedCustomer.fromMap) match {
+      case None => Future.successful(unauthorized(request))
+      case Some(ad) => block(new IdentifiedCustomerRequest(ad, request))
     }
 }

--- a/app/io/flow/play/controllers/FlowRequests.scala
+++ b/app/io/flow/play/controllers/FlowRequests.scala
@@ -72,6 +72,14 @@ class OrgRequest[A](
   val environment: Environment = auth.environment
 }
 
+class IdentifiedCustomerRequest[A](
+  val auth: OrgAuthData,
+  request: Request[A]
+) extends WrappedRequest[A](request) {
+  val organization: String = auth.organization
+  val environment: Environment = auth.environment
+}
+
 /**
   * Any type of request that contains checkout data
   */

--- a/app/io/flow/play/util/AuthData.scala
+++ b/app/io/flow/play/util/AuthData.scala
@@ -458,12 +458,23 @@ object OrgAuthData {
   object Org {
 
     /**
-      * Parses either an identified org or session org (or None)
+      * Parses either an identified org or customer org or session org (or None)
       */
     def fromMap(data: Map[String, String])(implicit logger: RollbarLogger): Option[io.flow.play.util.OrgAuthData] = {
       Identified.fromMap(data)
         .orElse(Customer.fromMap(data))
         .orElse(Session.fromMap(data))
+    }
+  }
+
+  object IdentifiedCustomer {
+
+    /**
+      * Parses either an identified org or customer org (or None)
+      */
+    def fromMap(data: Map[String, String])(implicit logger: RollbarLogger): Option[io.flow.play.util.OrgAuthData] = {
+      Identified.fromMap(data)
+        .orElse(Customer.fromMap(data))
     }
   }
 

--- a/test/io/flow/play/util/AuthDataSpec.scala
+++ b/test/io/flow/play/util/AuthDataSpec.scala
@@ -94,4 +94,22 @@ class AuthDataSpec extends LibPlaySpec {
     session must be(authDataSession)
   }
 
+  "OrgAuthData.IdentifiedCustomer - customer" in {
+    val orgAuthDataCustomer = AuthHeaders.organizationCustomer(org = createTestId())
+    val customerData: Map[String, String] = Map(
+      Fields.CreatedAt -> orgAuthDataCustomer.createdAt.toString,
+      Fields.RequestId -> orgAuthDataCustomer.requestId,
+      Fields.Organization -> orgAuthDataCustomer.organization,
+      Fields.Environment -> orgAuthDataCustomer.environment.toString,
+      Fields.Session -> orgAuthDataCustomer.session.id,
+      Fields.Customer -> orgAuthDataCustomer.customer.number
+    )
+
+    val auth: Option[AuthData] = OrgAuthData.IdentifiedCustomer.fromMap(customerData)(logger)
+
+    auth.get.isInstanceOf[OrgAuthData.Customer] must be(true)
+    val customer = auth.get.asInstanceOf[OrgAuthData.Customer]
+    customer must be(orgAuthDataCustomer)
+  }
+
 }


### PR DESCRIPTION
This authorization will be used for resources that require an API key or JWT (customer) only.  For example, will be used to create customers from within checkout but also allows for direct integration.