### PR TITLE
MockConfig should not be a singleton

### DIFF
--- a/app/io/flow/play/clients/MockConfig.scala
+++ b/app/io/flow/play/clients/MockConfig.scala
@@ -4,7 +4,6 @@ import io.flow.play.util.{Config, DefaultConfig}
 
 import scala.collection.mutable
 
-@javax.inject.Singleton
 class MockConfig @javax.inject.Inject() (
   defaultConfig: DefaultConfig
 ) extends Config {


### PR DESCRIPTION
In testing, we will be summoning MockConfig multiple times. We don't want properties that are set in one test to leak over to another test.