### PR TITLE
better travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,18 @@ language: scala
 scala:
   - 2.12.10
 jdk:
-  - openjdk10
+  - openjdk8
 cache:
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+    - $HOME/.sbt
+    - $HOME/.cache/coursier
 script: 
   - sbt ++$TRAVIS_SCALA_VERSION clean compile flowLintLib test doc
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm -f
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm -f
 branches:
   only:
     - master
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete


### PR DESCRIPTION
Updates:
- Use same JDK in test and prod (openjdk8)
- add ~/.cache/coursier to cache. Coursier is the [new dependency resolver](https://www.scala-sbt.org/release/docs/sbt-1.3-Release-Notes.html#Library+management+with+Coursier) in sbt 1.3.0
- move \"Tricks to avoid unnecessary cache updates\" to a before_cache section, as recommended by the [sbt docs](https://www.scala-sbt.org/1.x/docs/Travis-CI-with-sbt.html#Caching)