### PR TITLE
Generic authentication

### DIFF
--- a/app/io/flow/play/controllers/FlowActionInvokeBlockHelper.scala
+++ b/app/io/flow/play/controllers/FlowActionInvokeBlockHelper.scala
@@ -21,7 +21,7 @@ trait FlowActionInvokeBlockHelper {
   protected lazy val authExpirationTimeSeconds: Int =
     config.optionalPositiveInt("FLOW_AUTH_EXPIRATION_SECONDS").getOrElse(DefaultAuthExpirationTimeSeconds)
 
-  protected def auth[T <: AuthData](headers: Headers)(f: Map[String, String] => Option[T]): Option[T] =
+  def auth[T <: AuthData](headers: Headers)(f: Map[String, String] => Option[T]): Option[T] =
     headers.get(AuthHeaders.Header).flatMap { v => parse(v)(f) }
 
   def parse[T <: AuthData](value: String)(f: Map[String, String] => Option[T]): Option[T] =

--- a/app/io/flow/play/util/RequestFactory.scala
+++ b/app/io/flow/play/util/RequestFactory.scala
@@ -1,0 +1,36 @@
+package io.flow.play.util
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.Request
+
+import io.flow.log.RollbarLogger
+import io.flow.play.controllers._
+
+@Singleton
+class RequestFactory @Inject()(myConfig: Config)(implicit logger: RollbarLogger) {
+
+    private val helper = new FlowActionInvokeBlockHelper { val config = myConfig }
+    private def build[A, B <: AuthData](
+        request: Request[A],
+        authDataFromMap: Map[String, String] => Option[B],
+    ): Option[B] = helper.auth(request.headers)(authDataFromMap(_))
+
+    def anonymous[A](request: Request[A]): AnonymousRequest[A] = {
+        val auth = build(request, AuthData.Anonymous.fromMap)
+            .getOrElse(AuthData.Anonymous.Empty) // Create an empty header here so at least requestId tracking can start
+
+        new AnonymousRequest(auth, request)
+    }
+
+    def checkoutOrg[A](request: Request[A]): Option[CheckoutOrgRequest[A]] = build(request, OrgAuthData.CheckoutOrg.fromMap).map(new CheckoutOrgRequest(_, request))
+    def checkout[A](request: Request[A]): Option[CheckoutRequest[A]] = build(request, OrgAuthData.Checkout.fromMap).map(new CheckoutRequest(_, request))
+    def customerOrg[A](request: Request[A]): Option[CustomerOrgRequest[A]] = build(request, OrgAuthData.Customer.fromMap).map(new CustomerOrgRequest(_, request))
+    def customer[A](request: Request[A]): Option[CustomerRequest[A]] = build(request, AuthData.Customer.fromMap).map(new CustomerRequest(_, request))
+    def identifiedCustomer[A](request: Request[A]): Option[IdentifiedCustomerRequest[A]] = build(request, OrgAuthData.IdentifiedCustomer.fromMap).map(new IdentifiedCustomerRequest(_, request))
+    def identifiedOrg[A](request: Request[A]): Option[IdentifiedOrgRequest[A]] = build(request, OrgAuthData.Identified.fromMap).map(new IdentifiedOrgRequest(_, request))
+    def identified[A](request: Request[A]): Option[IdentifiedRequest[A]] = build(request, AuthData.Identified.fromMap).map(new IdentifiedRequest(_, request))
+    def org[A](request: Request[A]): Option[OrgRequest[A]] = build(request, OrgAuthData.Org.fromMap).map(new OrgRequest(_, request))
+    def sessionOrg[A](request: Request[A]): Option[SessionOrgRequest[A]] = build(request, OrgAuthData.Session.fromMap).map(new SessionOrgRequest(_, request))
+    def session[A](request: Request[A]): Option[SessionRequest[A]] = build(request, AuthData.Session.fromMap).map(new SessionRequest(_, request))
+
+}


### PR DESCRIPTION
Strongly typed controllers parse Play requests and generate Play responses to guaranty types. Note this means that some of the play specific features are now wrapped - specifically the `ActionBuilder`s logic to injectable factories. 
