### PR TITLE
Make authorization trait sealed

### DIFF
--- a/app/io/flow/play/controllers/Authorization.scala
+++ b/app/io/flow/play/controllers/Authorization.scala
@@ -7,7 +7,7 @@ import pdi.jwt.{Jwt, JwtAlgorithm, JwtJson, JwtOptions}
 
 import scala.util.{Failure, Success}
 
-trait Authorization
+sealed trait Authorization
 
 case class JwtToken(userId: String) extends Authorization
 case class Token(token: String) extends Authorization


### PR DESCRIPTION
Fixes:
```
[error] /Users/mbryzek/code/flowcommerce/dependency/api/app/controllers/util/IdentificationWithFallback.scala:43:9: match may not be exhaustive.
[error] It would fail on the following input: (x: io.flow.play.controllers.Authorization forSome x not in (io.flow.play.controllers.JwtToken, io.flow.play.controllers.Token))
[error]         token match {
```

which is now detected in scala 2.13.5