### PR TITLE
IdentifiedChannel: Accept 'channel id' and verify it matches the header

### DIFF
--- a/app/io/flow/play/util/RequestFactory.scala
+++ b/app/io/flow/play/util/RequestFactory.scala
@@ -32,6 +32,6 @@ class RequestFactory @Inject()(myConfig: Config)(implicit logger: RollbarLogger)
     def org[A](request: Request[A]): Option[OrgRequest[A]] = build(request, OrgAuthData.Org.fromMap).map(new OrgRequest(_, request))
     def sessionOrg[A](request: Request[A]): Option[SessionOrgRequest[A]] = build(request, OrgAuthData.Session.fromMap).map(new SessionOrgRequest(_, request))
     def session[A](request: Request[A]): Option[SessionRequest[A]] = build(request, AuthData.Session.fromMap).map(new SessionRequest(_, request))
-    def identifiedChannel[A](request: Request[A]): Option[IdentifiedChannelRequest[A]] = build(request, ChannelAuthData.IdentifiedChannel.fromMap).map(new IdentifiedChannelRequest(_, request))
+    def identifiedChannel[A](request: Request[A], channelId: String): Option[IdentifiedChannelRequest[A]] = build(request, ChannelAuthData.IdentifiedChannel.fromMap).map(new IdentifiedChannelRequest(_, request)).filter(_.channel == channelId)
 
 }


### PR DESCRIPTION
The idea here is to enforce that the channel id in the headers matches the expected channel id in the request.

Current:
```
  override def getById(request: Request[AnyContent], channelId: String): Future[GetById] = {
  ...
  _ <- EitherT.fromOption[Future](requestFactory.identifiedChannel(request), Get.HTTP401)
  }
```

With this change, we pass in the channelId from the request parameters and guarantee that the returned IdentifiedChannel matches:
```
  override def getById(request: Request[AnyContent], channelId: String): Future[GetById] = {
  ...
  _ <- EitherT.fromOption[Future](requestFactory.identifiedChannel(request, channelId), Get.HTTP401)
  }
```

This removes the need to assume the service is behind something like API Proxy which correctly validated the channel id