### PR TITLE
remove role from identified channel

### DIFF
--- a/app/io/flow/play/util/AuthData.scala
+++ b/app/io/flow/play/util/AuthData.scala
@@ -519,7 +519,6 @@ object ChannelAuthData {
     override val requestId: String,
     channel: String,
     user: UserReference,
-    role: Role,
     session: Option[FlowSession],
     customer: Option[CustomerReference]
   ) extends ChannelAuthData {
@@ -528,7 +527,6 @@ object ChannelAuthData {
       base.copy(
         user = Some(user),
         channel = Some(channel),
-        role = Some(role),
       )
     }
 
@@ -538,15 +536,14 @@ object ChannelAuthData {
 
     def fromMap(data: Map[String, String])(implicit logger: RollbarLogger): Option[IdentifiedChannel] = {
       AuthDataMap.fromMap(data) { dm =>
-        (dm.user, dm.channel, dm.role) match {
-          case (Some(user), Some(channel), Some(role)) => {
+        (dm.user, dm.channel) match {
+          case (Some(user), Some(channel)) => {
             Some(
               IdentifiedChannel(
                 createdAt = dm.createdAt,
                 requestId = dm.requestId,
                 user = user,
                 channel = channel,
-                role = role,
                 session = dm.session,
                 customer = dm.customer
               )

--- a/app/io/flow/play/util/AuthHeaders.scala
+++ b/app/io/flow/play/util/AuthHeaders.scala
@@ -147,7 +147,6 @@ object AuthHeaders {
   def channel(
     user: UserReference,
     channel: String,
-    role: Role = Role.Member,
     requestId: String = generateRequestId(),
     session: Option[FlowSession] = None,
     customer: Option[CustomerReference] = None
@@ -156,7 +155,6 @@ object AuthHeaders {
       requestId = requestId,
       user = user,
       channel = channel,
-      role = role,
       session = session,
       customer = customer
     )

--- a/test/io/flow/play/controllers/FlowActionsSpec.scala
+++ b/test/io/flow/play/controllers/FlowActionsSpec.scala
@@ -171,7 +171,6 @@ class FlowActionsSpec extends LibPlaySpec with FlowActionInvokeBlockHelper {
         requestId = createTestId(),
         user = user,
         channel = createTestId(),
-        role = Role.Member,
         session = None,
         customer = None
       )

--- a/test/io/flow/play/util/AuthDataSpec.scala
+++ b/test/io/flow/play/util/AuthDataSpec.scala
@@ -36,17 +36,15 @@ class AuthDataSpec extends LibPlaySpec {
     val auth = AuthHeaders.channel(UserReference("user-1"), "testify")
     auth.user.id must be("user-1")
     auth.channel must be("testify")
-    auth.role must be(Role.Member)
   }
 
   "AuthData.channel" in {
     val requestId = "test-request"
     val sessionId = "F51session"
     val customer = "customerRef"
-    val auth = AuthHeaders.channel(UserReference("user-1"), "testify", Role.Admin, requestId = requestId, session = Some(FlowSession(sessionId)), customer = Some(CustomerReference(customer)))
+    val auth = AuthHeaders.channel(UserReference("user-1"), "testify", requestId = requestId, session = Some(FlowSession(sessionId)), customer = Some(CustomerReference(customer)))
     auth.user.id must be("user-1")
     auth.channel must be("testify")
-    auth.role must be(Role.Admin)
     auth.requestId must be(requestId)
     auth.session must be(Some(FlowSession(sessionId)))
     auth.customer must be(Some(CustomerReference(customer)))


### PR DESCRIPTION
Channel tokens are authorized differently than organizations.  There is not separate authorization step (like we have for organizations) at time time, and thus, now roles.