### PR TITLE
Add support for a generic Retry on Future

### DIFF
--- a/app/io/flow/play/util/RetryFutures.scala
+++ b/app/io/flow/play/util/RetryFutures.scala
@@ -1,0 +1,181 @@
+package io.flow.play.util
+
+import io.flow.log.RollbarLogger
+import play.api.libs.concurrent.Futures
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+import scala.reflect.ClassTag
+
+@Singleton
+class RetryFutures @Inject() (log: RollbarLogger, futures: Futures) {
+
+  /** Retries a Future on specific failures.
+    * @param conf
+    *   configuration for retrying the Future
+    * @param logger
+    *   decorated logger to use when retrying, for instance with a fingerprint. If None, the default logger will be
+    *   used.
+    */
+  def run[T](conf: RetryConfiguration, logger: Option[RollbarLogger] = None)(f: => Future[T])(implicit
+    ec: ExecutionContext,
+  ): Future[T] = {
+    val _logger = decorateLogger(logger, conf)
+    val deadline = conf.overallTimeout.map(_.fromNow)
+    conf.timeout match {
+      case Some(t) =>
+        // If a timeout is set, we need to create a new configuration for the timeout exception
+        val newConf = conf.onExceptions[TimeoutException]
+        runRec(newConf, futures.timeout(t)(f), 1, deadline, _logger)
+      case None =>
+        runRec(conf, f, 1, deadline, _logger)
+    }
+  }
+
+  private def runRec[A](
+    conf: RetryConfiguration,
+    f: => Future[A],
+    attempt: Int,
+    deadline: Option[Deadline],
+    logger: RollbarLogger,
+  )(implicit ec: ExecutionContext): Future[A] = {
+    f.recoverWith {
+      case e if conf.forExceptions.isDefinedAt(e) && attempt < conf.maxAttempts && deadline.forall(_.hasTimeLeft()) =>
+        val delay = conf.delayPolicy.delay(attempt)
+        logRetry(conf.maxAttempts, attempt, delay, logger, e)
+        futures.delayed(delay)(runRec(conf, f, attempt + 1, deadline, logger))
+      case e =>
+        // If we are out of attempts or the deadline has passed, we fail with the last exception
+        Future.failed[A](e)
+    }
+  }
+
+  private def logRetry(
+    maxAttempts: Int,
+    attempt: Int,
+    delay: FiniteDuration,
+    logger: RollbarLogger,
+    throwable: Throwable,
+  ): Unit =
+    if (shouldLogAttempt(attempt))
+      logger
+        .withKeyValue("attempt", attempt)
+        .withKeyValue("delay_ms", delay.toMillis)
+        .info(
+          s"Received error ${throwable.getMessage} after attempt ($attempt/$maxAttempts). " +
+            s"Retrying in ${delay.toMillis} ms ...",
+        )
+
+  private def decorateLogger(
+    logger: Option[RollbarLogger],
+    conf: RetryConfiguration,
+  ): RollbarLogger = {
+    val withMa = logger
+      .getOrElse(log)
+      .withKeyValue("max_attempts", conf.maxAttempts)
+      .withSendToRollbar(false)
+    val withTo = conf.timeout.fold(withMa)(t => withMa.withKeyValue("timeout_ms", t.toMillis))
+    val withOt = conf.overallTimeout.fold(withTo)(ot => withTo.withKeyValue("overall_timeout_ms", ot.toMillis))
+    withOt
+  }
+
+  private def shouldLogAttempt(attempt: Int): Boolean =
+    attempt < 10 || attempt % 10 == 0
+
+}
+
+/** Configuration for retrying a Future on specified failures.
+  * @param delayPolicy
+  *   function to calculate the delay between attempts. The first attempt will be called with 1, the second with 2, etc.
+  * @param maxAttempts
+  *   maximum number of attempts to retry the Future. Default is 120.
+  * @param timeout
+  *   timeout after which to retry if the Future has not completed
+  * @param overallTimeout
+  *   overall timeout after which to stop retrying
+  * @param forExceptions
+  *   Partial function to match exceptions that should be retried. By default, no exceptions are retried. Use
+  *   `forException` to add exceptions to the partial function.
+  *
+  * @example
+  *   {{{
+  *   val retryConfig =
+  *     RetryConfiguration
+  *        .withExponentialBackoff(1.seconds, 2)
+  *        .withMaxAttempts(10)
+  *        .withTimeout(Some(5.seconds))
+  *        .withOverallTimeout(Some(2.minutes))
+  *        .onExceptions[MyException]
+  *        .onExceptionsMatching[IllegalArgumentException](_.getMessage.contains("foo"))
+  *        .onExceptions {
+  *          case e @ UnitResponse(status) if Set(429, 430).contains(status) => ()
+  *          case e: ArithmeticException if e.getMessage.contains("baz") => ()
+  *        }
+  *   }}}
+  */
+case class RetryConfiguration(
+  delayPolicy: DelayPolicy,
+  maxAttempts: Int = 120,
+  timeout: Option[FiniteDuration] = None,
+  overallTimeout: Option[FiniteDuration] = None,
+  forExceptions: PartialFunction[Throwable, Unit] = PartialFunction.empty,
+) {
+  def withMaxAttempts(maxAttempts: Int): RetryConfiguration = this.copy(maxAttempts = maxAttempts)
+  def withDelayFunction(delayFunction: DelayPolicy): RetryConfiguration = this.copy(delayPolicy = delayFunction)
+  def withTimeout(timeout: Option[FiniteDuration]): RetryConfiguration = this.copy(timeout = timeout)
+  def withOverallTimeout(overallTimeout: Option[FiniteDuration]): RetryConfiguration =
+    this.copy(overallTimeout = overallTimeout)
+
+  def onExceptionsMatching[T <: Throwable](matches: T => Boolean)(implicit ct: ClassTag[T]): RetryConfiguration =
+    this.copy(forExceptions = this.forExceptions.orElse { case e: T if matches(e) => () })
+  def onExceptions[T <: Throwable](implicit ct: ClassTag[T]): RetryConfiguration =
+    this.copy(forExceptions = this.forExceptions.orElse { case _: T => () })
+  def onExceptions(pf: PartialFunction[Throwable, Unit]): RetryConfiguration =
+    this.copy(forExceptions = this.forExceptions.orElse(pf))
+
+  def withFixedDelay(delay: FiniteDuration): RetryConfiguration =
+    this.copy(delayPolicy = FixedDelayPolicy(delay))
+
+  def withExponentialBackoff(baseDelay: FiniteDuration, factor: Long = 2L): RetryConfiguration =
+    this.copy(delayPolicy = ExponentialBackoffPolicy(baseDelay, factor))
+}
+
+trait DelayPolicy extends Product with Serializable {
+  def delay(attempt: Int): FiniteDuration
+}
+case class FixedDelayPolicy(delay: FiniteDuration) extends DelayPolicy {
+  override def delay(attempt: Int): FiniteDuration = delay
+}
+case class ExponentialBackoffPolicy(baseDelay: FiniteDuration, factor: Long = 2L) extends DelayPolicy {
+  override def delay(attempt: Int): FiniteDuration =
+    if (attempt == 1) baseDelay
+    else baseDelay * BigInt(factor).pow(attempt - 1).toLong
+}
+
+object RetryConfiguration {
+  def withFixedDelay(
+    delay: FiniteDuration,
+    maxAttempts: Int = 120,
+    timeout: Option[FiniteDuration] = None,
+    overallTimeout: Option[FiniteDuration] = None,
+    forExceptions: PartialFunction[Throwable, Unit] = PartialFunction.empty,
+  ): RetryConfiguration =
+    RetryConfiguration(FixedDelayPolicy(delay), maxAttempts, timeout, overallTimeout, forExceptions)
+
+  def withExponentialBackoff(
+    baseDelay: FiniteDuration,
+    factorDelay: Long = 2L,
+    maxAttempts: Int = 120,
+    timeout: Option[FiniteDuration] = None,
+    overallTimeout: Option[FiniteDuration] = None,
+    forExceptions: PartialFunction[Throwable, Unit] = PartialFunction.empty,
+  ): RetryConfiguration =
+    RetryConfiguration(
+      ExponentialBackoffPolicy(baseDelay, factorDelay),
+      maxAttempts,
+      timeout,
+      overallTimeout,
+      forExceptions,
+    )
+}

--- a/test/io/flow/play/util/RetrySpec.scala
+++ b/test/io/flow/play/util/RetrySpec.scala
@@ -4,6 +4,7 @@ import org.mockito.Mockito._
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.concurrent.Futures
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,6 +13,7 @@ class RetryFuturesSpec extends LibPlaySpec with ScalaFutures with MockitoSugar {
 
   private val retryFutures = app.injector.instanceOf[RetryFutures]
   implicit private val ec: ExecutionContext = app.actorSystem.dispatcher
+  private val futures = app.injector.instanceOf[Futures]
 
   def config(
     delay: FiniteDuration = 10.millis,
@@ -74,6 +76,23 @@ class RetryFuturesSpec extends LibPlaySpec with ScalaFutures with MockitoSugar {
       retryFutures.run(conf)(f.apply()).failed.futureValue(Timeout(1.second)) mustBe a[IllegalArgumentException]
     }
 
+    "retry once when first attempt exceeds timeout" in {
+      val f = mock[() => Future[Int]]
+
+      when(f.apply())
+        .thenReturn(futures.delayed(200.millis)(Future.successful(1))) // simulate slow Future
+        .thenReturn(Future.successful(42)) // Succeeds on retry
+
+      val conf = RetryConfiguration
+        .withFixedDelay(delay = 10.millis, maxAttempts = 2)
+        .withTimeout(Some(50.millis)) // This will trigger a TimeoutException
+
+      val result = retryFutures.run(conf)(f.apply()).futureValue(Timeout(1.second))
+
+      result mustBe 42
+      verify(f, times(2)).apply() // Confirm exactly 2 calls (1 timeout + 1 retry)
+    }
+
     "retry and succeed before overall timeout" in {
       val f = mock[() => Future[Int]]
       when(f.apply())
@@ -110,6 +129,7 @@ class RetryFuturesSpec extends LibPlaySpec with ScalaFutures with MockitoSugar {
       // Verify we called the function 4 times
       verify(f, times(4)).apply()
     }
+
   }
 }
 

--- a/test/io/flow/play/util/RetrySpec.scala
+++ b/test/io/flow/play/util/RetrySpec.scala
@@ -1,0 +1,116 @@
+package io.flow.play.util
+
+import org.mockito.Mockito._
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+class RetryFuturesSpec extends LibPlaySpec with ScalaFutures with MockitoSugar {
+
+  private val retryFutures = app.injector.instanceOf[RetryFutures]
+  implicit private val ec: ExecutionContext = app.actorSystem.dispatcher
+
+  def config(
+    delay: FiniteDuration = 10.millis,
+    maxAttempts: Int = 5,
+    overallTimeout: Option[FiniteDuration] = None,
+    forExceptions: PartialFunction[Throwable, Unit] = PartialFunction.empty,
+  ): RetryConfiguration =
+    RetryConfiguration
+      .withFixedDelay(delay, maxAttempts = maxAttempts, overallTimeout = overallTimeout, forExceptions = forExceptions)
+
+  "RetryFutures" should {
+
+    "retry and succeed after matching errors" in {
+      val f = mock[() => Future[Int]]
+      when(f.apply())
+        .thenReturn(Future.failed(MyException(429)))
+        .thenReturn(Future.failed(MyException(501)))
+        .thenReturn(Future.failed(new IllegalArgumentException("retryable")))
+        .thenReturn(Future.successful(1))
+
+      val conf = config(maxAttempts = 10)
+        .onExceptions {
+          case MyException(429) => ()
+          case MyException(501) => ()
+        }
+        .onExceptions[IllegalArgumentException]
+
+      retryFutures.run(conf)(f.apply()).futureValue(Timeout(1.second)) mustBe 1
+    }
+
+    "fail after non-matching error" in {
+      val f = mock[() => Future[Int]]
+      when(f.apply())
+        .thenReturn(Future.failed(MyException(429)))
+        .thenReturn(Future.failed(MyException(404)))
+
+      val conf = config(maxAttempts = 10).onExceptions { case MyException(429) => () }
+
+      retryFutures.run(conf)(f.apply()).failed.futureValue(Timeout(1.second)) mustBe a[MyException]
+    }
+
+    "fail after max attempts exceeded" in {
+      val f = mock[() => Future[Int]]
+      val max = 3
+      (1 to max).foreach(_ => when(f.apply()).thenReturn(Future.failed(new IllegalArgumentException("retryable"))))
+
+      val conf = config(maxAttempts = max)
+        .onExceptions[IllegalArgumentException]
+
+      retryFutures.run(conf)(f.apply()).failed.futureValue(Timeout(1.second)) mustBe a[IllegalArgumentException]
+    }
+
+    "fail after overall timeout exceeded" in {
+      val f = mock[() => Future[Int]]
+      (1 to 4).foreach(_ => when(f.apply()).thenReturn(Future.failed(new IllegalArgumentException)))
+
+      val conf = config(delay = 80.millis, maxAttempts = 100, overallTimeout = Some(200.millis))
+        .onExceptions[IllegalArgumentException]
+
+      retryFutures.run(conf)(f.apply()).failed.futureValue(Timeout(1.second)) mustBe a[IllegalArgumentException]
+    }
+
+    "retry and succeed before overall timeout" in {
+      val f = mock[() => Future[Int]]
+      when(f.apply())
+        .thenReturn(Future.failed(new IllegalArgumentException))
+        .thenReturn(Future.failed(new IllegalArgumentException))
+        .thenReturn(Future.successful(42))
+
+      val conf = config(delay = 50.millis, maxAttempts = 10, overallTimeout = Some(200.millis))
+        .onExceptions[IllegalArgumentException]
+
+      retryFutures.run(conf)(f.apply()).futureValue(Timeout(1.second)) mustBe 42
+    }
+
+    "retry with exponential backoff and succeed" in {
+      val f = mock[() => Future[Int]]
+
+      // Always fail for first 3 attempts, then succeed
+      when(f.apply())
+        .thenReturn(Future.failed(new IllegalArgumentException("boom 1")))
+        .thenReturn(Future.failed(new IllegalArgumentException("boom 2")))
+        .thenReturn(Future.failed(new IllegalArgumentException("boom 3")))
+        .thenReturn(Future.successful(99))
+
+      val baseDelay = 10.millis
+
+      val conf = RetryConfiguration
+        .withExponentialBackoff(baseDelay, factorDelay = 2L, maxAttempts = 5)
+        .onExceptions[IllegalArgumentException]
+
+      val result = retryFutures.run(conf)(f.apply()).futureValue(Timeout(1.second))
+
+      result mustBe 99
+
+      // Verify we called the function 4 times
+      verify(f, times(4)).apply()
+    }
+  }
+}
+
+case class MyException(status: Int) extends Exception


### PR DESCRIPTION
Resolves [LOG-3907]

Generic version of existing `Retry`:
 - https://github.com/flowcommerce/shopify/blob/main/shared/app/utils/Retry.scala
 - https://github.com/flowcommerce/label/blob/main/shared/app/utils/Retry.scala


[LOG-3907]: https://flowio.atlassian.net/browse/LOG-3907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ